### PR TITLE
Make http://prezi3.iiif.io/ work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
-
+env:
+  global:
+    - ROOT_INSTALL="true"
 before_install:
   - export NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   - npm install -g grunt-cli
@@ -19,9 +21,11 @@ jdk:
   - oraclejdk8
 dist: precise
 
-before_deploy: if [[ ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} != master ]]; then
+before_deploy: if [[ ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} != master && ${ROOT_INSTALL} != "true" ]]; then
+    echo "Building relative ${ROOT_INSTALL}";
     bundle exec jekyll clean && bundle exec jekyll build --baseurl /api/${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH};
   else
+    echo "Building at root ${ROOT_INSTALL}";
     bundle exec jekyll clean && bundle exec jekyll build;
   fi
 


### PR DESCRIPTION
Travis changes to make a branch that has a sub domain of IIIF link to the root rather than the branch name. Once this is merged it should make the css and links work for:

http://prezi3.iiif.io/api/presentation/3.0/

Once this is merged Ill look at putting a forward for:

http://preview.iiif.io/api/prezi3/api/presentation/3.0/

so it forwards to the above as once this is merged the css and links won't work for preview.