### PR TITLE
remove datatype assertions from contexts

### DIFF
--- a/source/api/image/1/context.json
+++ b/source/api/image/1/context.json
@@ -6,19 +6,15 @@
     "dcterms": "http://purl.org/dc/terms/",
 
     "height": {
-      "@type": "xsd:integer",
       "@id": "exif:height"
     },
     "width": {
-      "@type": "xsd:integer",
       "@id": "exif:width"
     },
     "tile_height": {
-      "@type": "xsd:integer",
       "@id": "iiif:tileHeight"
     },
     "tile_width": {
-      "@type": "xsd:integer",
       "@id": "iiif:tileWidth"
     },
     "scale_factors": {

--- a/source/api/image/2/context.json
+++ b/source/api/image/2/context.json
@@ -11,104 +11,79 @@
     "sc": "http://iiif.io/api/presentation/2#",
 
     "baseUriRedirect": {
-      "@id": "iiif:baseUriRedirectFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:baseUriRedirectFeature"
     },
     "cors": {
-      "@id": "iiif:corsFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:corsFeature"
     },
     "regionByPct": {
-      "@id": "iiif:regionByPctFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:regionByPctFeature"
     },
     "regionByPx": {
-      "@id": "iiif:regionByPxFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:regionByPxFeature"
     },
     "regionSquare": {
-      "@id": "iiif:regionSquareFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:regionSquareFeature"
     },
     "rotationArbitrary": {
-      "@id": "iiif:arbitraryRotationFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:arbitraryRotationFeature"
     },
     "rotationBy90s": {
-      "@id": "iiif:rotationBy90sFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:rotationBy90sFeature"
     },
     "mirroring": {
-      "@id": "iiif:mirroringFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:mirroringFeature"
     },
     "sizeAboveFull": {
-      "@id": "iiif:sizeAboveFullFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:sizeAboveFullFeature"
     },
     "sizeByForcedWh": {
-      "@id": "iiif:sizeByForcedWHFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:sizeByForcedWHFeature"
     },
     "sizeByH": {
-      "@id": "iiif:sizeByHFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:sizeByHFeature"
     },
     "sizeByPct": {
-      "@id": "iiif:sizeByPctFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:sizeByPctFeature"
     },
     "sizeByW": {
-      "@id": "iiif:sizeByWFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:sizeByWFeature"
     },
     "sizeByWh": {
-      "@id": "iiif:sizeByWHFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:sizeByWHFeature"
     },
     "sizeByWhListed": {
-      "@id": "iiif:sizeByWHListedFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:sizeByWHListedFeature"
     },
     "sizeByConfinedWh": {
-      "@id": "iiif:sizeByConfinedWHFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:sizeByConfinedWHFeature"
     },
     "sizeByDistortedWh": {
-      "@id": "iiif:sizeByDistortedWHFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:sizeByDistortedWHFeature"
     },
     "profileLinkHeader": {
-      "@id": "iiif:profileLinkHeaderFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:profileLinkHeaderFeature"
     },
     "canonicalLinkHeader": {
-      "@id": "iiif:canonicalLinkHeaderFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:canonicalLinkHeaderFeature"
     },
     "jsonldMediaType": {
-      "@id": "iiif:jsonLdMediaTypeFeature",
-      "@type": "iiif:Feature"
+      "@id": "iiif:jsonLdMediaTypeFeature"
     },
     "height": {
-      "@id": "exif:height",
-      "@type": "xsd:integer"
+      "@id": "exif:height"
     },
     "width": {
-      "@id": "exif:width",
-      "@type": "xsd:integer"
+      "@id": "exif:width"
     },
     "scaleFactors": {
-      "@id": "iiif:scaleFactor",
-      "@type": "xsd:integer"
+      "@id": "iiif:scaleFactor"
     },
     "formats": {
-      "@id": "iiif:format",
-      "@type": "xsd:string"
+      "@id": "iiif:format"
     },
     "qualities": {
-      "@id": "iiif:quality",
-      "@type": "xsd:string"
+      "@id": "iiif:quality"
     },
     "sizes": {
       "@id": "iiif:hasSize",

--- a/source/api/presentation/2/context.json
+++ b/source/api/presentation/2/context.json
@@ -121,11 +121,9 @@
       "@type": "@id"
     },
     "height": {
-      "@type": "xsd:integer",
       "@id": "exif:height"
     },
     "width": {
-      "@type": "xsd:integer",
       "@id": "exif:width"
     },
     "attribution": {

--- a/source/api/search/0/context.json
+++ b/source/api/search/0/context.json
@@ -2,7 +2,7 @@
   "@context": {
     "search": "http://iiif.io/api/search/0#",
 
-    "ignored": {"@id": "search:ignored", "@container": "@set", "@type": "xsd:string"},
+    "ignored": {"@id": "search:ignored", "@container": "@set"},
     "match": {"@id": "search:match"},
     "before": {"@id": "search:before"},
     "after": {"@id": "search:after"},

--- a/source/api/search/1/context.json
+++ b/source/api/search/1/context.json
@@ -2,7 +2,7 @@
   "@context": {
     "search": "http://iiif.io/api/search/1#",
 
-    "ignored": {"@id": "search:ignored", "@container": "@set", "@type": "xsd:string"},
+    "ignored": {"@id": "search:ignored", "@container": "@set"},
     "match": {"@id": "search:match"},
     "before": {"@id": "search:before"},
     "after": {"@id": "search:after"},


### PR DESCRIPTION
Closes #1272 ; removes data types and class assertions from contexts, which prevent compaction (and don't do what we thought they did anyway)