### PR TITLE
Simplify root apps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 env:
   global:
-    - ROOT_BRANCHES="master prezi3 simplfy_root_apps"
+    - ROOT_BRANCHES="master prezi3"
 before_install:
   - export NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 env:
   global:
-    - ROOT_INSTALL="true"
+    - ROOT_BRANCHES="master prezi3"
 before_install:
   - export NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   - npm install -g grunt-cli
@@ -21,7 +21,7 @@ jdk:
   - oraclejdk8
 dist: precise
 
-before_deploy: if [[ ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} != master && ${ROOT_INSTALL} != "true" ]]; then
+before_deploy: if [[ ${ROOT_BRANCHES} =~ .*${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}.* ]]; then
     echo "Building relative ${ROOT_INSTALL}";
     bundle exec jekyll clean && bundle exec jekyll build --baseurl /api/${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH};
   else

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 env:
   global:
-    - ROOT_BRANCHES="master prezi3"
+    - ROOT_BRANCHES="master prezi3 simplfy_root_apps"
 before_install:
   - export NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ jdk:
 dist: precise
 
 before_deploy: if [[ ${ROOT_BRANCHES} =~ .*${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}.* ]]; then
-    echo "Building relative ${ROOT_INSTALL}";
-    bundle exec jekyll clean && bundle exec jekyll build --baseurl /api/${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH};
-  else
     echo "Building at root ${ROOT_INSTALL}";
     bundle exec jekyll clean && bundle exec jekyll build;
+  else
+    echo "Building relative ${ROOT_INSTALL}";
+    bundle exec jekyll clean && bundle exec jekyll build --baseurl /api/${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH};
   fi
 
 deploy:

--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ Commits to `github.com/iiif/iiif.io` will automatically be deployed to `iiif.io`
     * link to root website from api website (not relative to this repo) `[hyperlink text]({{ page.webprefix }}/end/point)`
     * External link `[anchor-text](http://example.com/end/point)`
     * Reference link `[text][link_name]` where link_name is expanded at the bottom of the page.
+ * If this branch has a domain name associated with it e.g. prezi3.iiif.io then add the name of the branch to the `ROOT_BRANCHES` variable in the `.travis.yml`. Note branch names are sperated by a space.    


### PR DESCRIPTION
Made a change so you specifically have to edit the .travis.yml to say its a root branch (i.e. it has a domain like prezi3.iiif.io). This means if you create a branch from prezi3 the preview link will work. 