### PR TITLE
Moving events to the top level

### DIFF
--- a/source/_data/navigation.yml
+++ b/source/_data/navigation.yml
@@ -11,5 +11,8 @@
   name: Community
   url: /community/
 -
+  name: Events
+  url: /event/
+-
   name: News
   url: /news/


### PR DESCRIPTION
This change is to make the API website consistent with the iiif.io website with Events at the top level. Currently they are buried in the community section and see very little use. 

The events page now contains a list of IIIF events people are attending and so should change more frequently. 

This pull request needs to be done close to https://github.com/IIIF/website/pull/71.