### PR TITLE
grunt fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ scripts/factory.py
 scripts/factory.pyc
 .ruby-version
 package-lock.json
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+
 env:
   global:
     - ROOT_BRANCHES="master prezi3"
@@ -10,16 +11,21 @@ install:
   - bundle install
   - npm install grunt grunt-html --save-dev
 
+# randomly having java opts set breaks grunt-html
+before_script:
+  - unset _JAVA_OPTIONS
+
+  # looks like grunt-html use the W3C validator at: https://github.com/validator/validator
 script:
   - rake ci
 
 # environment
 language: ruby
 rvm:
-  - "2.2.3"
+  - "2.4.1"
 jdk:
   - oraclejdk8
-dist: precise
+dist: trusty
 
 before_deploy: if [[ ${ROOT_BRANCHES} =~ .*${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}.* ]]; then
     echo "Building at root ${ROOT_INSTALL}";

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,8 @@ module.exports = function(grunt) {
             /cc:attributionURL/,
             /Attribute “rel” not allowed on element “span”/,
             /Consider using the “h1” element/,
-				/Attribute “integrity” not allowed on element “script”/
+            /Attribute “integrity” not allowed on element “script”/,
+            /This document appears to be written in French but the/
           ]
         },
         src : '_site/**/*.html'

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.5",
-    "grunt-html": "~3.0.0"
+    "grunt-html": "^9.0.0"
   },
   "scripts": {
     "test": "grunt test"

--- a/source/api/image/validator/index.html
+++ b/source/api/image/validator/index.html
@@ -9,9 +9,9 @@ layout: spec
 
 		<link property="" href="{{ site.url }}{{ site.baseurl }}/api/image/validator/css/cupertino/jquery-ui-1.8.17.custom.css" type="text/css" rel="stylesheet">
 		<link property="" href="{{ site.url }}{{ site.baseurl }}/api/image/validator/css/iiif.css" type="text/css" rel="stylesheet">
-		<script type="text/javascript" src="{{ site.url }}{{ site.baseurl }}/js/vendor/jquery-1.11.1.min.js"></script>
-		<script type="text/javascript" src="{{ site.url }}{{ site.baseurl }}/js/vendor/jquery-ui-1.8.17.custom.min.js"></script>
-		<script type="text/javascript" src="{{ site.url }}{{ site.baseurl }}/api/image/validator/js/select.js"></script>
+		<script src="{{ site.url }}{{ site.baseurl }}/js/vendor/jquery-1.11.1.min.js"></script>
+		<script src="{{ site.url }}{{ site.baseurl }}/js/vendor/jquery-ui-1.8.17.custom.min.js"></script>
+		<script src="{{ site.url }}{{ site.baseurl }}/api/image/validator/js/select.js"></script>
 
 <section class="wrapper">
 	<form method="get" action="results/">

--- a/source/api/image/validator/results.html
+++ b/source/api/image/validator/results.html
@@ -11,9 +11,9 @@ redirect_from:
 
 		<link property="" href="{{ site.url }}{{ site.baseurl }}/api/image/validator/css/cupertino/jquery-ui-1.8.17.custom.css" type="text/css" rel="stylesheet"/>
 		<link property="" href="{{ site.url }}{{ site.baseurl }}/api/image/validator/css/iiif.css" type="text/css" rel="stylesheet"/>
-		<script type="text/javascript" src="{{ site.url }}{{ site.baseurl }}/js/vendor/jquery-1.11.1.min.js"></script>
-		<script type="text/javascript" src="{{ site.url }}{{ site.baseurl }}/js/vendor/jquery-ui-1.8.17.custom.min.js"></script>
-		<script type="text/javascript" src="{{ site.url }}{{ site.baseurl }}/api/image/validator/js/results.js"></script>
+		<script src="{{ site.url }}{{ site.baseurl }}/js/vendor/jquery-1.11.1.min.js"></script>
+		<script src="{{ site.url }}{{ site.baseurl }}/js/vendor/jquery-ui-1.8.17.custom.min.js"></script>
+		<script src="{{ site.url }}{{ site.baseurl }}/api/image/validator/js/results.js"></script>
 
 
 

--- a/source/api/presentation/validator/service/index.html
+++ b/source/api/presentation/validator/service/index.html
@@ -53,8 +53,8 @@ If you would like to use the validator programatically, there are two options:
 </ul>
 </div>
     <!-- AJAX code for form submission -->
-    <script type="text/javascript">
-      
+    <script>
+
       // Call out to the validation service and get a result
       function handleSubmission(e) {
         e.preventDefault();
@@ -92,6 +92,6 @@ If you would like to use the validator programatically, there are two options:
       // Set up event handler.
       $('#submit-url').on("click", handleSubmission);
     </script>
- 
+
 
 </section>


### PR DESCRIPTION
Port of @glenrobson's changes in #1514 but without the API spec changes:

This is now building OK. So after some extensive investigation it looks like grunt-html was updated to 9.0.0 but not sure why as it should have been pinned to 3.0.0 or a semantically similar version. 

Anyway version 9 wasn't working due to the node version we were using was too old to support it. On the image-rights branch I've got it working by changing:
 * the travis build server we are using to trusty
 * increasing the versions for ruby and grunt-html 
 * removing the JAVA_OPTIONS which was causing grunt-html to fail in the travis file
 * Fixing some validation errors that the new grunt-html picked up (no longer necessary to have the type attribution in ```<script type="text/javascript">```)
 * Added an ignore when grunt-html thought http://preview.iiif.io/api/image-rights/api/annex/ was written in French...

Now that grunt-html `9.0.0` is out it will affect any branches that don't have this fix.  I suggest you merge this branch into prezi3 then update other branches from that. 