### PR TITLE
Fix link to sizes deprecation warning in Image 3.0 change log

### DIFF
--- a/source/_includes/links.md
+++ b/source/_includes/links.md
@@ -29,6 +29,7 @@
 [image11]: {{ site.url }}{{ site.baseurl }}/api/image/1.1/ "Image API 1.1"
 [image20-change-log]: {{ site.url }}{{ site.baseurl }}/api/image/2.0/change-log/ "Change Log for Version 2.0"
 [image21-change-log]: {{ site.url }}{{ site.baseurl }}/api/image/2.1/change-log/ "Change Log for Version 2.1"
+[image21-dep-sizes]: {{ site.url }}{{ site.baseurl }}/api/image/2.1/#dep-sizes "Deprecation Warning"
 [image21-full-dep]: {{ site.url }}{{ site.baseurl }}/api/image/2.1/#full-dep "Deprecation Warning"
 [image21-size]: {{ site.url }}{{ site.baseurl }}/api/image/2.1/#size "4.2. Size"
 [image21-size-dep]: {{ site.url }}{{ site.baseurl }}/api/image/2.1/#size-dep "Deprecation Warning"

--- a/source/api/image/3.0/change-log.md
+++ b/source/api/image/3.0/change-log.md
@@ -77,7 +77,7 @@ In version 2.1 the value of the `service` property could be a single value or an
 
 #### 1.2.8. Remove feature names `sizeByWhListed` and `sizeByForcedWh`
 
-Per the [deprecation warning][image21-full-dep] in the previous version, the feature names `sizeByWhListed` and `sizeByForcedWh` have been removed. See PR [#727](https://github.com/IIIF/api/pull/727).
+Per the [deprecation warning][image21-dep-sizes] in the previous version, the feature names `sizeByWhListed` and `sizeByForcedWh` have been removed. See PR [#727](https://github.com/IIIF/api/pull/727).
 
 #### 1.2.9. Remove feature name `sizeByDistortedWh`
 


### PR DESCRIPTION
Trivial fix to fix link that currently goes to wrong deprecation warning