### PR TITLE
Updating links to work with https

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,7 @@ task :ci do
   build_site
   sh 'grunt test'
   sh 'scripts/check_json.py -v'
+  sh 'scripts/check_mixedcontent.sh'
   Rake::Task['spec'].invoke
   Rake::Task['check_html'].invoke
 end

--- a/_config.yml
+++ b/_config.yml
@@ -62,4 +62,4 @@ defaults:
     scope:
       path: ""
     values:
-      webprefix: "http://iiif.io"
+      webprefix: "https://iiif.io"

--- a/scripts/check_mixedcontent.sh
+++ b/scripts/check_mixedcontent.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+SCANNER_VERSION="0.1"
+
+mkdir files
+cd files
+curl -LO "https://github.com/IIIF/phantomjs-mixed-content-scan/archive/$SCANNER_VERSION.tar.gz"
+tar zxvf "$SCANNER_VERSION.tar.gz"
+mv phantomjs-mixed-content-scan-$SCANNER_VERSION/* .
+rmdir phantomjs-mixed-content-scan-$SCANNER_VERSION
+./check_mixedcontent.sh ../_site/test
+rm *
+cd ..
+rmdir files

--- a/source/_includes/head.html
+++ b/source/_includes/head.html
@@ -4,10 +4,10 @@
     <meta name="description" content="{{ site.data.organization.description }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/normalize.min.css">
-    <link href='http://fonts.googleapis.com/css?family=Raleway:100,300,500' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,400italic,600,700' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Lato' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Raleway:100,300,500' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,400italic,600,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Lato' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/main.css">
     <link type="application/atom+xml" rel="alternate" href="{{page.webprefix}}/news/atom.xml"/>
     <script src="{{ site.url }}{{ site.baseurl }}/js/vendor/modernizr-2.6.2-respond-1.1.0.min.js"></script>

--- a/source/_includes/spec-head.html
+++ b/source/_includes/spec-head.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/syntax.css">
     <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/main.css">
     <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/spec-doc{% if page.cssversion %}{{page.cssversion}}{% else %}{{ page.major }}{% endif %}.css">
-    <link href='http://fonts.googleapis.com/css?family=Ubuntu+Mono' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Ubuntu+Mono' rel='stylesheet' type='text/css'>
     <script src="{{ site.url }}{{ site.baseurl }}/js/vendor/modernizr-2.6.2-respond-1.1.0.min.js"></script>
     <script src="https://code.jquery.com/jquery-2.2.3.min.js" integrity="sha256-a23g1Nt4dtEYOj7bR+vTu7+T8VP13humZFBJNIYoEJo=" crossorigin="anonymous"></script>
     <script src="{{ site.url }}{{ site.baseurl }}/js/vendor/anchor.min.js"></script>

--- a/source/api/image/1.1/change-log.html
+++ b/source/api/image/1.1/change-log.html
@@ -15,8 +15,8 @@ redirect_from:
     <meta name="viewport" content="width=device-width">
 
     <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/normalize.min.css">
-    <link href='http://fonts.googleapis.com/css?family=Raleway:100,300,500' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Raleway:100,300,500' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/main.css">
 
     <script src="{{ site.url }}{{ site.baseurl }}/js/vendor/modernizr-2.6.2-respond-1.1.0.min.js"></script>

--- a/source/api/image/1.1/compliance.html
+++ b/source/api/image/1.1/compliance.html
@@ -15,8 +15,8 @@ redirect_from:
     <meta name="viewport" content="width=device-width">
 
     <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/normalize.min.css">
-    <link href='http://fonts.googleapis.com/css?family=Raleway:100,300,500' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Raleway:100,300,500' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/main.css">
 
     <script src="{{ site.url }}{{ site.baseurl }}/js/vendor/modernizr-2.6.2-respond-1.1.0.min.js"></script>

--- a/source/api/image/validator/js/select.js
+++ b/source/api/image/validator/js/select.js
@@ -1,5 +1,5 @@
 function Tester() {
-	this.baseUrl = 'http://iiif.io/api/image/validator/service/';
+	this.baseUrl = 'https://iiif.io/api/image/validator/service/';
 	
 	this.categories = {
 		1: 'Info/Identifier',
@@ -10,8 +10,8 @@ function Tester() {
 		6: 'Format',
 		7: 'HTTP'
 	};
-	
-	this.tests = {};	
+
+	this.tests = {};
 	this.currentTests = [];
 	this.cancelled = false;
 }
@@ -66,7 +66,7 @@ Tester.prototype.fetchTestList = function() {
 				$('#c_'+test.category).append('<div class="input">'+
 					'<input id="'+test.id+'" type="checkbox" name="'+test.id+'"/><label for="'+test.id+'">'+label+'</label>'+
 				'</div>');
-			}					
+			}
 			$('#tests input').click(function(ev) {
 				$('#level').val('-1');
 			});
@@ -79,7 +79,7 @@ Tester.prototype.fetchTestList = function() {
 Tester.prototype.init = function() {
 
 	this.fetchTestList();
-	
+
 	$('#dialog').dialog({
 		autoOpen: false,
 		modal: true,
@@ -91,7 +91,7 @@ Tester.prototype.init = function() {
 			}
 		}
 	});
-		
+
 	$('#inputs ins').each(function(index, el) {
 		var msg = '';
 		switch (index) {
@@ -108,12 +108,12 @@ Tester.prototype.init = function() {
 	}).click($.proxy(function(ev) {
 		this.showMessage('Help', $(ev.target).data('msg'));
 	}, this));
-	
+
 	$('#level').change($.proxy(function(ev) {
 		var level = parseInt($(ev.target).val());
 		this.doLevelCheck(level);
 	}, this));
-	
+
 	$('#version').change($.proxy(function(ev) {
 		// regenerate test options
 		this.fetchTestList();
@@ -121,18 +121,18 @@ Tester.prototype.init = function() {
 
 	$('#run_tests').click($.proxy(function(ev) {
 		var errors = '';
-		
+
 		var uri = $('#server').val();
 		if (uri == '') {
 			errors += 'The Server field is empty.\n';
 		}
-		
+
 		var prefix = $('#prefix').val();
 		if (prefix == '') {
 			errors += 'The Prefix field is empty.\n';
 		}
-		
-		var id = $('#identifier').val();		
+
+		var id = $('#identifier').val();
 		if (errors == '') {
 			$('#tabs').hide();
 			$('#results').show();
@@ -140,7 +140,7 @@ Tester.prototype.init = function() {
 		} else {
 			this.showMessage('Error', errors);
 		}
-		
+
 	}, this));
 
 };

--- a/source/api/metadata/1.0/index.html
+++ b/source/api/metadata/1.0/index.html
@@ -18,8 +18,8 @@ redirect_from:
     <meta name="viewport" content="width=device-width">
 
     <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/normalize.min.css">
-    <link href='http://fonts.googleapis.com/css?family=Raleway:100,300,500' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Raleway:100,300,500' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/main.css">
 
 <style>

--- a/source/model/shared-canvas/1.0/index.html
+++ b/source/model/shared-canvas/1.0/index.html
@@ -1078,6 +1078,6 @@ The editors would like to thank the following for their valuable contributions:
 
 </div>
 
-&nbsp;<br/><a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-nc-sa/3.0/88x31.png" /></a><span property="dct:title" rel="dct:type">This work </span> by <a href="{{ page.webprefix }}" property="cc:attributionName" rel="cc:attributionURL">the IIIF</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/">Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License</a>.
+&nbsp;<br/><a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://licensebuttons.net/l/by-nc-sa/3.0/88x31.png" /></a><span property="dct:title" rel="dct:type">This work </span> by <a href="{{ page.webprefix }}" property="cc:attributionName" rel="cc:attributionURL">the IIIF</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/">Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License</a>.
 </body>
 </html>


### PR DESCRIPTION
Adding test to check for mixed content

Pointing fonts to use https versions.

Plan is to run the iiif.io site in parallel as both http and https while we look at what needs to change in the site. Things that might need to change are:

 * Fixtures (moving from http://iiif.io to https://iiif.io
 * Specs? do we need to change the link to the context to use the https link?

I've checked the validators and they should work OK as they don't have any client side code to retrieve http manifests. 