### PR TITLE
Revert "Recommend support for HEAD in Image and Presentation 3.0"

### DIFF
--- a/source/api/image/3.0/index.md
+++ b/source/api/image/3.0/index.md
@@ -814,8 +814,6 @@ A recipe for setting this header on the Apache HTTP Server is shown in the [Apac
 
 ## 7. Server Responses
 
-Servers _MUST_ support the HTTP GET method for retrieval of Image API resources. Servers _SHOULD_ support the HTTP OPTIONS method as part of the [CORS][image30-cors-response] preflight request pattern, and it is _RECOMMENDED_ that implementations also support the HTTP HEAD method.
-
 ### 7.1. CORS
 
 Servers _SHOULD_ support reuse of Image API resources by following the relevant requirements of the [CORS specification][org-w3c-cors], including the `Access-Control-Allow-Origin` header and the preflight request pattern. A recipe for enabling these behaviors is provided in the [Apache HTTP Server Implementation Notes][notes-apache-conditional-content-type].

--- a/source/api/presentation/3.0/index.md
+++ b/source/api/presentation/3.0/index.md
@@ -1465,7 +1465,7 @@ For Annotation Collections with many Annotations, there will be many pages. The 
 
 ## 6. HTTP Requests and Responses
 
-This section describes the _RECOMMENDED_ request and response interactions for the API. The REST and simple HATEOAS approach is followed where an interaction will retrieve a description of the resource, and additional calls may be made by following links obtained from within the description. All of the requests use the HTTP GET method; creation and update of resources is not covered by this specification. It is _RECOMMENDED_ that implementations also support HTTP HEAD requests.
+This section describes the _RECOMMENDED_ request and response interactions for the API. The REST and simple HATEOAS approach is followed where an interaction will retrieve a description of the resource, and additional calls may be made by following links obtained from within the description. All of the requests use the HTTP GET method; creation and update of resources is not covered by this specification.
 
 ### 6.1. URI Recommendations
 


### PR DESCRIPTION
Reverts #1656, this should have been against `image-prezi-rc2` instead of `master`