### PR TITLE
Revert "Add note about change to canonical form of tile requests"

### DIFF
--- a/source/api/image/3.0/change-log.md
+++ b/source/api/image/3.0/change-log.md
@@ -34,7 +34,7 @@ Per the [deprecation warning][image21-full-dep] in the previous version, the val
 
 #### 1.1.2. Change canonical form of size parameter to _`w,h`_
 
-Per the [deprecation warning][image21-full-dep] and the [inconsistency warning][image21-size-inconsistency] about the size parameter in the previous version, the canonical form of the size parameter is now _`w,h`_ unless `max` is requested. This resolves the inconsistency between the server-preferred values in the `sizes` object, and the canonical form of the size parameter. In order to request preferred sizes, a client should use the `width` and `height` values from `sizes` unmodified to build the _`w,h`_ size to request. Clients should also use canonical form of the size parameter _`w,h`_ when constructing tile requests. See issues [#544](https://github.com/IIIF/api/issues/544) and [#678](https://github.com/IIIF/api/issues/678).
+Per the [deprecation warning][image21-full-dep] and the [inconsistency warning][image21-size-inconsistency] about the size parameter in the previous version, the canonical form of the size parameter is now _`w,h`_ unless `max` is requested. This resolves the inconsistency between the server-preferred values in the `sizes` object, and the canonical form of the size parameter. In order to request preferred sizes, a client should use the `width` and `height` values from `sizes` unmodified to build the _`w,h`_ size to request. See issues [#544](https://github.com/IIIF/api/issues/544) and [#678](https://github.com/IIIF/api/issues/678).
 
 #### 1.1.3. Size parameter value must not scale image to larger than the extracted region
 


### PR DESCRIPTION
Reverts IIIF/api#1657, this should have been against `image-prezi-rc2` instead of `master`