### PR TITLE
Update ffi version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
     ethon (0.11.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.5)
-    ffi (1.9.23)
+    ffi (1.9.24)
     forwardable-extended (2.6.0)
     html-proofer (3.8.0)
       activesupport (>= 4.2, < 6.0)


### PR DESCRIPTION
There is a warning for ffi 1.9.23 which is addressed by updating to 1.9.24. I'm not sure why this was pinned but from a look at various of the API docs I don't see anything broken.

I think this should be merged into `master` and then we can later update `image-prezi-rc2`