### PR TITLE
Remove leftover redirect from discovery/0.1

### DIFF
--- a/source/api/discovery/0.1/index.md
+++ b/source/api/discovery/0.1/index.md
@@ -9,9 +9,6 @@ major: 0
 minor: 1
 patch: 0
 pre: final
-redirect_from:
-  - /api/discovery/index.html
-  - /api/discovery/0/index.html
 ---
 
 


### PR DESCRIPTION
The redirect for `/api/discovery/` was left in 0.1 as well as being present in 0.2. The PR removes from 0.1 so that the redirect is to 0.2. Fixes #1770