### PR TITLE
Add term definitions for 'Size' and 'Tile' to combined-context.json

### DIFF
--- a/source/api/presentation/3/combined-context.json
+++ b/source/api/presentation/3/combined-context.json
@@ -299,6 +299,9 @@
     "sizeByW": "iiif_image:sizeByWFeature",
     "sizeByWh": "iiif_image:sizeByWHFeature",
 
+    "Size": "iiif_image:Size",
+    "Tile": "iiif_image:Tile",
+
     "ImageService1": {
       "@id": "http://iiif.io/api/image/1#ImageService",
       "@context": [


### PR DESCRIPTION
The members of [`sizes`](https://iiif.io/api/image/3.0/#53-sizes) in the image information response have an optional `type` which must always be `Size`. `Size` is not defined in the `combined-context.json`, neither [online](https://iiif.io/api/presentation/3/combined-context.json) nor in the master or the image-prezi-rc2 branch. But I guess it should ultimately expand to `http://iiif.io/api/image/3#Size`.
Same issue with `Tile` / `http://iiif.io/api/image/3#Tile` as type for each object in `tiles`.

I don't know if I selected the right branch to base this PR on...