### PR TITLE
remove profileLinkHeader from v2/l2

### DIFF
--- a/source/api/image/2/level2.json
+++ b/source/api/image/2/level2.json
@@ -9,7 +9,6 @@
     "baseUriRedirect",
     "cors",
     "jsonldMediaType",
-    "profileLinkHeader",
     "regionByPct",
     "regionByPx",
     "rotationBy90s",


### PR DESCRIPTION
Closes #1766 (as it's not semantically versioned, we can do this at any time)