### PR TITLE
Tone down beta warning

### DIFF
--- a/source/_includes/links.md
+++ b/source/_includes/links.md
@@ -15,8 +15,7 @@
 [discovery02]: {{ site.url }}{{ site.baseurl }}/api/discovery/0.2/ "IIIF Change Discovery API"
 [discovery03]: {{ site.url }}{{ site.baseurl }}/api/discovery/0.3/ "IIIF Change Discovery API"
 [github-discovery-issues]: https://github.com/IIIF/discovery/issues
-[github-milestone-image-3]: https://github.com/IIIF/iiif.io/milestone/7
-[github-milestone-prezi-3]: https://github.com/IIIF/iiif.io/milestone/8
+[github-milestone-image-prezi-3]: https://github.com/IIIF/api/milestone/22
 [github-webanno-437]: https://github.com/w3c/web-annotation/issues/437
 [groups-av]: {{ site.url }}{{ site.baseurl }}/community/groups/av/ "IIIF A/V Working Group"
 [groups-discovery]: {{ site.url }}{{ site.baseurl }}/community/groups/discovery/

--- a/source/api/image/3.0/index.md
+++ b/source/api/image/3.0/index.md
@@ -34,7 +34,7 @@ __Previous Version:__ [2.1.1][image21]
 {% include copyright.md %}
 
 __Status Warning__
-This is a BETA DRAFT. Implementation is encouraged but implementers should be aware that there may be additional changes to this document before final release. See [remaining issues][github-milestone-image-prezi-3] on Github.
+This is a BETA DRAFT. Implementation is encouraged but implementers should be aware that there may be additional changes to this document before the final release. See [remaining issues][github-milestone-image-prezi-3] on Github.
 {: .warning}
 
 ----

--- a/source/api/image/3.0/index.md
+++ b/source/api/image/3.0/index.md
@@ -34,7 +34,7 @@ __Previous Version:__ [2.1.1][image21]
 {% include copyright.md %}
 
 __Status Warning__
-This is a work in progress and may change without any notices. Implementers should be aware that this document is not stable. Implementers are likely to find the specification changing in incompatible ways. Those interested in implementing this document before it reaches beta or release stages should join the [mailing list][iiif-discuss] and take part in the discussions, and follow the [emerging issues][github-milestone-image-3] on Github.
+This is a BETA DRAFT. Implementation is encouraged but implementers should be aware that there may be additional changes to this document before final release. See [remaining issues][github-milestone-image-prezi-3] on Github.
 {: .warning}
 
 ----

--- a/source/api/presentation/3.0/index.md
+++ b/source/api/presentation/3.0/index.md
@@ -33,7 +33,7 @@ __Previous Version:__ [2.1.1][prezi21]
 {% include copyright.md %}
 
 __Status Warning__<br/>
-This is a work in progress and may change without any notices. Implementers should be aware that this document is not stable. Implementers are likely to find the specification changing in incompatible ways. Those interested in implementing this document before it reaches beta or release stages should join the [mailing list][iiif-discuss] and take part in the discussions, and follow the [emerging issues][github-milestone-prezi-3] on Github.
+This is a BETA DRAFT. Implementation is encouraged but implementers should be aware that there may be additional changes to this document before final release. See [remaining issues][github-milestone-image-prezi-3] on Github.
 {: .warning}
 
 ----

--- a/source/api/presentation/3.0/index.md
+++ b/source/api/presentation/3.0/index.md
@@ -33,7 +33,7 @@ __Previous Version:__ [2.1.1][prezi21]
 {% include copyright.md %}
 
 __Status Warning__<br/>
-This is a BETA DRAFT. Implementation is encouraged but implementers should be aware that there may be additional changes to this document before final release. See [remaining issues][github-milestone-image-prezi-3] on Github.
+This is a BETA DRAFT. Implementation is encouraged but implementers should be aware that there may be additional changes to this document before the final release. See [remaining issues][github-milestone-image-prezi-3] on Github.
 {: .warning}
 
 ----


### PR DESCRIPTION
Closes #1891 

This is against `master` because we want to update the live beta docs. If merged it might also be good to merge that back into the `image_presi_rc3` branch to avoid any possible later conflicts.