### PR TITLE
Reorder the APIs in alphabetical order

### DIFF
--- a/source/api/index.md
+++ b/source/api/index.md
@@ -11,9 +11,10 @@ cssversion: 2
 | API                | Current Version |
 | ------------------ | --------------- |
 | Authentication API | [{{ site.auth_api.stable.major }}.{{ site.auth_api.stable.minor }}.{{ site.auth_api.stable.patch}}][auth{{ site.auth_api.stable.major }}{{ site.auth_api.stable.minor }}] |
+| Content Search API | [{{ site.search_api.stable.major }}.{{ site.search_api.stable.minor }}.{{ site.search_api.stable.patch }}][search{{ site.search_api.stable.major }}{{ site.search_api.stable.minor }}] |
 | Image API          | [{{ site.image_api.stable.major }}.{{ site.image_api.stable.minor }}.{{ site.image_api.stable.patch}}][image{{ site.image_api.stable.major }}{{ site.image_api.stable.minor }}] |
 | Presentation API   | [{{ site.presentation_api.stable.major }}.{{ site.presentation_api.stable.minor }}.{{ site.presentation_api.stable.patch }}][prezi{{ site.presentation_api.stable.major }}{{ site.presentation_api.stable.minor }}] |
-| Content Search API | [{{ site.search_api.stable.major }}.{{ site.search_api.stable.minor }}.{{ site.search_api.stable.patch }}][search{{ site.search_api.stable.major }}{{ site.search_api.stable.minor }}] |
+
 {: .api-table}
 
 ## Draft Specifications


### PR DESCRIPTION
After the merge of #1976, I noticed that the APIs are no longer in alphabetical order (my bad). 
In this commit, I didn't change the order of the translated APIs in Japanese as it has never been ordered that way (but perhaps it could).