### PR TITLE
Remove BETA label from 3.0 links

### DIFF
--- a/source/api/index.md
+++ b/source/api/index.md
@@ -75,12 +75,12 @@ IIIF Specifications are created and published following the [IIIF Editorial Proc
 
 
 [iiif-discuss]: mailto:iiif-discuss@googlegroups.com "Email Discussion List"
-[image30]: {{ site.url }}{{ site.baseurl }}/api/image/3.0/ "Image API v3.0 BETA"
+[image30]: {{ site.url }}{{ site.baseurl }}/api/image/3.0/ "Image API v3.0"
 [image21]: {{ site.url }}{{ site.baseurl }}/api/image/2.1/ "Image API v2.1"
 [image20]: {{ site.url }}{{ site.baseurl }}/api/image/2.0/ "Image API v2.0"
 [image11]: {{ site.url }}{{ site.baseurl }}/api/image/1.1/ "Image API v1.1"
 [image10]: {{ site.url }}{{ site.baseurl }}/api/image/1.0/ "Image API v1.0"
-[prezi30]: {{ site.url }}{{ site.baseurl }}/api/presentation/3.0/ "Presentation API v3.0 BETA"
+[prezi30]: {{ site.url }}{{ site.baseurl }}/api/presentation/3.0/ "Presentation API v3.0"
 [prezi21]: {{ site.url }}{{ site.baseurl }}/api/presentation/2.1/ "Presentation API v2.1"
 [prezi20]: {{ site.url }}{{ site.baseurl }}/api/presentation/2.0/ "Presentation API v2.0"
 [meta10]: {{ site.url }}{{ site.baseurl }}/api/metadata/1.0/ "Metadata API v1.0"


### PR DESCRIPTION
Mouseover of the `3.0.0` links for Image and Presentation shows a "BETA" label.

Closes #1981 