### PR TITLE
Add warning to Auth API 1.0 re: browsers and third-party cookies

### DIFF
--- a/source/api/auth/1.0/index.md
+++ b/source/api/auth/1.0/index.md
@@ -36,6 +36,10 @@ __Previous Version:__ [0.9.4][prev-version]
 
 ----
 
+__Warning__<br/>
+Recent developments in the browser community to discontinue support for third-party cookies have meant that IIIF Authentication API 1.0 workflows that rely on third-party cookies are now, or will soon be, obsolete in most browsers. The [IIIF Authentication TSG](https://iiif.io/community/groups/auth-tsg/) is currently working on the next iteration of the Auth specification, which should address the third-party cookies issue. Workflows relying on first-party cookies remain unaffected by these developments. For a more detailed discussion of the issues, see [What happens if there are no third-party cookies?](https://tom-crane.medium.com/what-happens-if-there-are-no-third-party-cookies-5ee5edb84d75).
+{: .alert}
+
 ## Table of Contents
 {:.no_toc}
 


### PR DESCRIPTION
This PR adds a warning to the auth 1.0 spec re: the issues with third-party cookies. Let me know if any issues with the wording, placement, etc. 

Resolves issue #1979 

Here's the text:

Warning: Recent developments in the browser community to discontinue support for third-party cookies have meant that IIIF Authentication API 1.0 workflows that rely on third-party cookies are now, or will soon be, obsolete in most browsers. The [IIIF Authentication TSG](https://iiif.io/community/groups/auth-tsg/) is currently working on the next iteration of the Auth specification, which should address the third-party cookies issue. Workflows relying on first-party cookies remain unaffected by these developments. For a more detailed discussion of the issues, see [What happens if there are no third-party cookies?](https://tom-crane.medium.com/what-happens-if-there-are-no-third-party-cookies-5ee5edb84d75).

And a screenshot:

<img width="1376" alt="Screen Shot 2021-04-08 at 10 03 13 AM" src="https://user-images.githubusercontent.com/3297113/114067473-b4eaed00-9851-11eb-86de-fa6064d4bfaf.png">