### PR TITLE
Fixing latest redirects

### DIFF
--- a/source/api/content-state/0.1/index.md
+++ b/source/api/content-state/0.1/index.md
@@ -9,9 +9,6 @@ major: 0
 minor: 1
 patch: 0
 pre: final
-redirect_from:
-  - /api/import/index.html
-  - /api/0/import/index.html
 ---
 
 

--- a/source/api/content-state/0.2/index.md
+++ b/source/api/content-state/0.2/index.md
@@ -9,9 +9,6 @@ major: 0
 minor: 2
 patch: 0
 pre: final
-redirect_from:
-  - /api/content-state/index.html
-  - /api/0/content-state/index.html
 ---
 
 

--- a/source/api/content-state/0.3/index.md
+++ b/source/api/content-state/0.3/index.md
@@ -9,9 +9,6 @@ major: 0
 minor: 3
 patch: 0
 pre: final
-redirect_from:
-  - /api/content-state/index.html
-  - /api/0/content-state/index.html
 ---
 
 

--- a/source/api/discovery/0.9/index.md
+++ b/source/api/discovery/0.9/index.md
@@ -10,7 +10,6 @@ minor: 9
 patch: 2
 pre: BETA
 redirect_from:
-  - /api/discovery/index.html
   - /api/discovery/0/index.html
 ---
 


### PR DESCRIPTION
Should fix:

 /api/discovery/ -> /api/discovery/1.0/

and

 /api/content-state/ -> /api/content-state/0.9/