### PR TITLE
rename pattern -> principle per @mprove

### DIFF
--- a/source/_includes/links.md
+++ b/source/_includes/links.md
@@ -5,7 +5,7 @@
 [annex-cookbook]: {{ site.cookbook_url | absolute_url }}/ "IIIF Cookbook"
 [annex-json-ld]: {{ site.api_url | absolute_url }}/annex/notes/jsonld/ "JSON-LD Frames Implementation Notes"
 [annex-oa]: {{ site.api_url | absolute_url }}/annex/openannotation/ "Open Annotation Extensions"
-[annex-patterns]: {{ site.api_url | absolute_url }}/annex/notes/design_patterns/
+[annex-patterns]: {{ site.api_url | absolute_url }}/annex/notes/design_principles/
 [annex-services]: {{ site.api_url | absolute_url }}/annex/services/ "Services Annex Document"
 [auth094]: {{ site.api_url | absolute_url }}/auth/0.9/ "Authentication API v0.9.4"
 [auth1-cookie-service]: {{ site.api_url | absolute_url }}/auth/1.0/#access-cookie-service "IIIF Authentication Cookie Service"

--- a/source/annex/index.md
+++ b/source/annex/index.md
@@ -20,4 +20,4 @@ hero:
 - [Note on Image Rotation Algorithm]({{ site.api_url | absolute_url }}/annex/notes/rotation/)
 - [Note on Semantic Versioning]({{ site.api_url | absolute_url }}/annex/notes/semver/)
 - [Disclaimer of Liability]({{ site.api_url | absolute_url }}/annex/notes/disclaimer/)
-- [IIIF Design Patterns]({{ site.api_url | absolute_url }}/annex/notes/design_patterns/)
+- [IIIF Design Principles]({{ site.api_url | absolute_url }}/annex/notes/design_principles/)

--- a/source/annex/notes/design_principles.md
+++ b/source/annex/notes/design_principles.md
@@ -194,6 +194,7 @@ Consistent data structures make code that consumes those structures easier to wr
 
 #### 3.4.1. Always Use Arrays for Multiple Value Properties
 {: #always-use-arrays-for-multiple-value-properties}
+{: #json-ld-design-patterns}
 
 If a property can ever have multiple values, it will always be an array even if it has only one value. This means that code can always iterate over the values without checking first to see if it's an array.  Thus we use `"language": [ "en" ]` and not `"language": "en"`.
 

--- a/source/annex/notes/design_principles.md
+++ b/source/annex/notes/design_principles.md
@@ -1,5 +1,5 @@
 ---
-title: "IIIF Design Patterns"
+title: "IIIF Design Principles"
 layout: spec
 tags: [annex, presentation-api, image-api]
 cssversion: 3
@@ -42,110 +42,110 @@ This document is not subject to [IIIF's versioning semantics][iiif-semver]. Chan
 ## 1. Overview
 {: #overview}
 
-This document aims to describe, rationalize, and document the design patterns that have evolved around the creation of the IIIF specifications to date. These patterns should be used as a guide for ongoing and future work in order to promote consistency across the growing number of IIIF specifications.
+This document aims to describe, rationalize, and document the design principles that have evolved around the creation of the IIIF specifications to date. These principles should be used as a guide for ongoing and future work in order to promote consistency across the growing number of IIIF specifications.
 
-The patterns do not speak to the process by which the specifications are written and managed over time.  For notes on the adopted approaches for these, please see:
+The principles do not speak to the process by which the specifications are written and managed over time.  For notes on the adopted approaches for these, please see:
 
   * [Editorial Process][editorial-process]: The community process of discussion, and the editorial process of writing, the specifications.
   * [Semantic Versioning][iiif-semver]: The interpretation of the semantic versioning pattern for managing change of APIs in a responsible and responsive manner.
 
 
-## 2. Design Patterns
-{: #design-patterns}
+## 2. Design Principles
+{: #design-principles}
 
 ### 2.1. Scope Design Through Shared Use Cases
 {: #scope-design-through-shared-use-cases}
 
 IIIF specifications are shaped by shared, documented, and well-understood use cases. Shared understanding promotes interoperability, and the specifications are more likely to be implemented if the results solve real, not speculative, problems. Assessment of use cases is a key factor in the process of determining which features should be included or prioritized.
 
-The intent of adopting this pattern is to keep the resulting specifications practical and to solve real problems.  Implementers will invest time in solutions that solve their problems, and not speculative or abstract ones.  If the use case is shared by multiple organizations, then there is a need for interoperability.
+The intent of adopting this principle is to keep the resulting specifications practical and to solve real problems.  Implementers will invest time in solutions that solve their problems, and not speculative or abstract ones.  If the use case is shared by multiple organizations, then there is a need for interoperability.
 
 ### 2.2. Select Solutions That Are as Simple as Possible and No Simpler
 {: #select-solutions-that-are-as-simple-as-possible-and-no-simpler}
 
 IIIF specifications should be designed to reduce the complexity to the lowest possible point at which the use cases that feed them can be met.  They should make simple things easy and complex things possible.  They should allow implementers to build up from a minimum viable product in stages and incrementally enable more complex use cases.
 
-The intent of adopting this pattern is to ensure the adoption of the specifications is as high as possible. Simplicity is often a trade-off between parties, and must take into account the generation and publishing of the data on the server side, and the consumption and processing of the data on the client side.
+The intent of adopting this principle is to ensure the adoption of the specifications is as high as possible. Simplicity is often a trade-off between parties, and must take into account the generation and publishing of the data on the server side, and the consumption and processing of the data on the client side.
 
 ### 2.3. Intelligently Manage Ramping Up
 {: #intelligently-manage-ramping-up}
 
 IIIF specifications should allow basic implementation with static on-disk files, often called "level 0", when possible. They should not require costly or complicated libraries or tooling to get started, nor computationally expensive runtime processing. A useful implementation should require only a way of hosting files that are accessible via a web server.
 
-The intent of adopting this pattern is to support simple and quick implementations as a way to encourage adoption.
+The intent of adopting this principle is to support simple and quick implementations as a way to encourage adoption.
 
 ### 2.4. Avoid Dependency on Specific Technologies
 {: #avoid-dependency-on-specific-technologies}
 
 IIIF specifications should avoid placing undue value on one technology or format over another, unless there is a clear benefit and the choice does not pose a significant barrier to entry.  While the APIs must make choices for the sake of interoperability, these choices must be weighed as to how closely tied they are to specific products or formats. For example, the JPEG format has extremely widespread adoption across multiple programming languages and environments. The JPEG2000 format, although technically superior, is not able to be rendered by most web browsers natively.  The first is an acceptable dependency, the second is not.
 
-The intent of adopting this pattern is to ensure that the specifications can be implemented in a variety of languages and styles.  It results from the combination of the previous two patterns.
+The intent of adopting this principle is to ensure that the specifications can be implemented in a variety of languages and styles.  It results from the combination of the previous two principles.
 
 ### 2.5. Use Resource Oriented Design
 {: #use-resource-oriented-design}
 
-IIIF specifications follow resource-centric design patterns, for example by using [REST][rest] interfaces rather than service or operation-centric design patterns. This carries on from the previous design patterns, and serves to provide a consistent and coherent pattern across many different functional areas.
+IIIF specifications follow resource-centric design principles, for example by using [REST][rest] interfaces rather than service or operation-centric design principles. This carries on from the previous design principles, and serves to provide a consistent and coherent principle across many different functional areas.
 
-The intent of adopting this pattern is to ensure that the specifications are cacheable and performant, at the same time as being easy to understand and implement.
+The intent of adopting this principle is to ensure that the specifications are cacheable and performant, at the same time as being easy to understand and implement.
 
 ### 2.6. Don't Break Web Caches
 {: #dont-break-web-caches}
 
 IIIF specifications are designed to work seamlessly with modern web caching infrastructure.  The specifications will ensure that representations can be trivially cached by intermediate systems without loss of fidelity or function.
 
-The intent of adopting this pattern is ensure performance and simplicity of implementation, and results from the previous patterns.
+The intent of adopting this principle is ensure performance and simplicity of implementation, and results from the previous principles.
 
 ### 2.7. Follow Linked Data Principles
 {: #follow-linked-data-principles}
 
 IIIF specifications conform to [Linked Data][lod], and relevant [web architecture][webarch] standards as defined by the W3C and IETF. They should not require an RDF based development stack to implement, but it must be possible to implement using one.  It should be possible to transform the data present in a single document back and forth between triples and the [JSON-LD][json-ld] serialization without loss, but not necessarily without the use of custom code.
 
-The intent of adopting this pattern is to ensure that the data published via IIIF specifications can be part of the Web, not just on the Web. The semantics of the properties and classes used in the APIs are therefore self-documenting and able to be shared.
+The intent of adopting this principle is to ensure that the data published via IIIF specifications can be part of the Web, not just on the Web. The semantics of the properties and classes used in the APIs are therefore self-documenting and able to be shared.
 
 ### 2.8. Design for JSON-LD First
 {: #design-for-json-ld-first}
 
 IIIF specifications that involve the description of resources, rather than the transfer of bitstreams, are designed for [JSON-LD][json-ld] as the primary serialization. This is comprised of publishing and maintaining a JSON-LD context document, and providing JSON-LD Frames.
 
-The intent of adopting this pattern is to ensure that the representation of the Linked Data is as easy to use as possible without the need for a full RDF development suite.  Developers must be able to treat the representation as plain JSON, with a predictable structure.  This ease of understanding increases the likelihood of wide spread adoption.
+The intent of adopting this principle is to ensure that the representation of the Linked Data is as easy to use as possible without the need for a full RDF development suite.  Developers must be able to treat the representation as plain JSON, with a predictable structure.  This ease of understanding increases the likelihood of wide spread adoption.
 
-The design patterns for this JSON representation are detailed in the next section.
+The design principles for this JSON representation are detailed in the next section.
 
 ### 2.9. Use Existing Standards Where Possible
 {: #use-existing-standards-where-possible}
 
 IIIF specifications should be consistent with and use existing open standards when possible.  This is tempered by the need for ease of understanding, implementation and the timing of standards evolution and updates.
 
-The intent of adopting this pattern is to ensure the continued integration of IIIF specifications with the wider web environment, and existing implementations.
+The intent of adopting this principle is to ensure the continued integration of IIIF specifications with the wider web environment, and existing implementations.
 
 ### 2.10. Follow Existing Best Practices
 {: #follow-existing-best-practices}
 
 IIIF specifications follow existing best practices for the standards that it adopts, including [JSON-LD best practices][jsonbp], [Linked Open Data best practices][lodbp], and [Data on the Web best practices][dwbp], where possible and appropriate.  Exceptions are made when the cost of following the best practice would prove to be a significant barrier to understanding or implementation, and hence adoption.
 
-The intent of adopting this pattern is to ensure the continued integration of IIIF specifications with the wider web environment. The design of IIIF specifications should be informed by existing and ongoing work, but evaluated as to the appropriateness of the application to the IIIF context.
+The intent of adopting this principle is to ensure the continued integration of IIIF specifications with the wider web environment. The design of IIIF specifications should be informed by existing and ongoing work, but evaluated as to the appropriateness of the application to the IIIF context.
 
 ### 2.11. Separate Concerns, Loosely Couple APIs
 {: #separate-concerns-loosely-couple-apis}
 
-In the well established pattern of doing one thing well, IIIF specifications should address their own area of concern and be loosely coupled rather than tightly bound together.  This allows for independent implementation and tooling, and simplifies the process for deployment by adopters and API updates by the community.  For example, it is possible to implement the [Image API][image-api] without the [Presentation API][presentation-api] and vice versa.  A counter example is that the [Search API][search-api] is necessarily more tightly linked to the Presentation API.
+In the well established principle of doing one thing well, IIIF specifications should address their own area of concern and be loosely coupled rather than tightly bound together.  This allows for independent implementation and tooling, and simplifies the process for deployment by adopters and API updates by the community.  For example, it is possible to implement the [Image API][image-api] without the [Presentation API][presentation-api] and vice versa.  A counter example is that the [Search API][search-api] is necessarily more tightly linked to the Presentation API.
 
-The intent of adopting this pattern is to ensure that the on-ramp for adopters was as easy and multi-entrant as possible.  The Presentation API can be a starting point for any of the other APIs, the Image API can be a starting point for the Presentation or [Authentication API][auth-api]s.  It also ensures the simplicity and scope of the APIs individually, as the complexity must be managed entirely within the API's specification.
+The intent of adopting this principle is to ensure that the on-ramp for adopters was as easy and multi-entrant as possible.  The Presentation API can be a starting point for any of the other APIs, the Image API can be a starting point for the Presentation or [Authentication API][auth-api]s.  It also ensures the simplicity and scope of the APIs individually, as the complexity must be managed entirely within the API's specification.
 
 ### 2.12. Define Success, Not Failure
 {: #define-success-not-failure}
 
-IIIF specifications define the functionality that can be expected to work and how to request it, and do not limit the interpretation of requests that are beyond the scope or current definition of the specification.  Any pattern outside of those defined by the APIs is able to be used by implementers, keeping in mind that future official API extensions might make it inconsistent.  For example, an implementation of the [Image API][image-api] can legitimately recognize its own specific parameter values for `quality` or `size`, but it should not change the interpretation of parameter values that are specified.
+IIIF specifications define the functionality that can be expected to work and how to request it, and do not limit the interpretation of requests that are beyond the scope or current definition of the specification.  Any principle outside of those defined by the APIs is able to be used by implementers, keeping in mind that future official API extensions might make it inconsistent.  For example, an implementation of the [Image API][image-api] can legitimately recognize its own specific parameter values for `quality` or `size`, but it should not change the interpretation of parameter values that are specified.
 
-The intent of adopting this pattern is to enable experimentation by implementers, thereby encouraging the early adoption and validation of new (minor) versions.
+The intent of adopting this principle is to enable experimentation by implementers, thereby encouraging the early adoption and validation of new (minor) versions.
 
 ### 2.13. Design for Worldwide Use
 {: #design-for-worldwide-use}
 
 IIIF specifications encourage internationalization efforts by requiring that text values of properties indicate their language, to support and encourage use around the world. IIIF assumes that text values of properties may have multiple values in multiple languages, rather than this being a special case.
 
-## 3. JSON-LD Design Patterns
-{: #json-ld-design-patterns}
+## 3. JSON-LD Design Principles
+{: #json-ld-design-principles}
 
 The representation of the information in JSON must be:
 
@@ -153,7 +153,7 @@ The representation of the information in JSON must be:
   * Understandable by developers without special training or documentation ;
   * Usable in a variety of application environments to ensure the widest adoption.
 
-These design patterns have been selected in order to maximize these features in the resulting APIs. Note that these patterns are not enforced for externally defined JSON-LD based systems which are then imported for use within the IIIF context. For example, the use of `motivation` for Annotations exactly follows the requirements of the Web Annotation Data Model which allows for both a JSON array or a single string, and does not follow the pattern recommended by [3.4.1][sec341] below.
+These design principles have been selected in order to maximize these features in the resulting APIs. Note that these principles are not enforced for externally defined JSON-LD based systems which are then imported for use within the IIIF context. For example, the use of `motivation` for Annotations exactly follows the requirements of the Web Annotation Data Model which allows for both a JSON array or a single string, and does not follow the principle recommended by [3.4.1][sec341] below.
 
 ### 3.1. Use Native Data Types
 {: #use-native-data-types}
@@ -170,7 +170,7 @@ JSON-LD defines two special keys in the data: `@id` (the URI of the resource) an
 ### 3.3. Use Consistent Naming Conventions
 {: #use-consistent-naming-conventions}
 
-Additional design patterns beyond the restricted range of characters are used to make the names of terms easier to remember and use.
+Additional design principles beyond the restricted range of characters are used to make the names of terms easier to remember and use.
 
 #### 3.3.1. Use CamelCase
 {: #use-camelcase}
@@ -185,7 +185,7 @@ All properties start with a lowercase letter, and all classes start with an uppe
 #### 3.3.3. Avoid Explicit Namespaces
 {: #avoid-explicit-namespaces}
 
-While JSON-LD allows for namespaced terms (`oa:Annotation`), this would require the use of a `:` character in the class or property name, which is ruled out by the special characters design pattern.  Thus use `Manifest` and not `sc:Manifest`.
+While JSON-LD allows for namespaced terms (`oa:Annotation`), this would require the use of a `:` character in the class or property name, which is ruled out by the special characters design principle.  Thus use `Manifest` and not `sc:Manifest`.
 
 ### 3.4. Use Consistent Structural Conventions
 {: #use-consistent-structural-conventions}

--- a/source/annex/notes/design_principles.md
+++ b/source/annex/notes/design_principles.md
@@ -3,6 +3,8 @@ title: "IIIF Design Principles"
 layout: spec
 tags: [annex, presentation-api, image-api]
 cssversion: 3
+redirect_from:
+  /annex/notes/design_patterns/
 editors:
   - name: Michael Appleby
     ORCID: https://orcid.org/0000-0002-1266-298X

--- a/source/annex/notes/index.html
+++ b/source/annex/notes/index.html
@@ -15,6 +15,6 @@ Documents:
   <li><a href="semver/">Note on Semantic Versioning</a></li>
   <li><a href="disclaimer/">Disclaimer of Liability</a></li>
   <li><a href="{{ site.root_url | absolute_url }}/community/policy/editorial/">IIIF Editorial Process</a></li>
-  <li><a href="design_principles/">IIIF Design Patterns</a></li>
+  <li><a href="design_principles/">IIIF Design Principles</a></li>
 </ul>
 </section>

--- a/source/annex/notes/index.html
+++ b/source/annex/notes/index.html
@@ -15,6 +15,6 @@ Documents:
   <li><a href="semver/">Note on Semantic Versioning</a></li>
   <li><a href="disclaimer/">Disclaimer of Liability</a></li>
   <li><a href="{{ site.root_url | absolute_url }}/community/policy/editorial/">IIIF Editorial Process</a></li>
-  <li><a href="design_patterns/">IIIF Design Patterns</a></li>
+  <li><a href="design_principles/">IIIF Design Patterns</a></li>
 </ul>
 </section>


### PR DESCRIPTION
Design patterns are "a general, reusable solution to a commonly occurring problem within a given context in software design." according to https://en.wikipedia.org/wiki/Software_design_pattern and @mprove. 

These are principles for those patterns, not the patterns themselves. This PR renames the page and s/pattern/principle/ in the document.