### PR TITLE
Add changelog link to Content Search 2 page

### DIFF
--- a/source/_includes/links.md
+++ b/source/_includes/links.md
@@ -268,6 +268,7 @@
 [search20]: {{ site.api_url | absolute_url }}/search/2.0/
 [search20-match-context]: {{ site.api_url | absolute_url }}/search/2.0/#match-context
 [search20-match-highlighting]: {{ site.api_url | absolute_url }}/search/2.0/#match-highlighting
+[search20-change-log]: {{ site.api_url | absolute_url }}/search/2.0/change-log/ "Content Search API 2.0 Change Log"
 [shared-canvas]: {{ site.api_url | absolute_url }}/model/shared-canvas/1.0/  "Shared Canvas Data Model"
 [recipe-process]: {{  site.cookbook_url | absolute_url }}/recipe/ "Cookbook process"
 [recipe-mvm-image]: {{ site.cookbook_url | absolute_url }}/recipe/0001-mvm-image/ "Simplest Manifest - Image"

--- a/source/search/2.0/index.md
+++ b/source/search/2.0/index.md
@@ -854,7 +854,7 @@ This specification is due primarily to the work of the [IIIF Content Search Tech
 
 | Date       | Description               |
 | ---------- | ------------------------- |
-| 2022-11-15 | Version 2.0 (Mr. Wigglesworth) |
+| 2022-11-15 | Version 2.0 (Mr. Wigglesworth) [View change log][search20-change-log]|
 | 2016-05-12 | Version 1.0 (Lost Summer) |
 | 2015-07-20 | Version 0.9 (Trip Life)   |
 {: .api-table}


### PR DESCRIPTION
Add a linkref in `links.md` and include it in the changelog section of the CS 2.0 index page