### PR TITLE
Update Content Search API versions

### DIFF
--- a/source/_data/apis.yml
+++ b/source/_data/apis.yml
@@ -43,11 +43,11 @@ search:
   image: assets/images/icons/search-group@2x.webp
   alt_text: Content Search API icon
   draft:
-    major: 1
+    major: 2
     minor: 0
     patch: 0
   stable:
-    major: 1
+    major: 2
     minor: 0
     patch: 0
 discovery:

--- a/source/search/1.0/index.md
+++ b/source/search/1.0/index.md
@@ -10,7 +10,6 @@ patch: 0
 pre: final
 cssversion: 2
 redirect_from:
-  - /search/index.html
   - /search/1/index.html
 editors:
   - name: Michael Appleby

--- a/source/search/2.0/index.md
+++ b/source/search/2.0/index.md
@@ -10,6 +10,7 @@ patch: 0
 pre: final
 cssversion: 2
 redirect_from:
+  - /search/index.html
   - /api/search/2/index.html
 editors:
   - name: Michael Appleby

--- a/source/search/2.0/index.md
+++ b/source/search/2.0/index.md
@@ -7,7 +7,7 @@ tags: [specifications, content-search-api]
 major: 2
 minor: 0
 patch: 0
-pre: alpha
+pre: final
 cssversion: 2
 redirect_from:
   - /api/search/2/index.html


### PR DESCRIPTION
* Bump the datafile version to 2.0
* Remove the alpha tag
* Update /search redirect to point to v2.0 page

Remaining question:
The previous version had a redirect from `/search/1/index.html` (and Prezi3 has `/presentation/3/index.html`) but here we have `/api/search/2/index.html`. Should that actually be `/search/2/index.html` (as presumably the /api/ part is a given due to the repo the markdown files are coming from and the github workflow here: https://github.com/IIIF/api/blob/main/.github/workflows/live.yml#L19)