### PR TITLE
Fixing redirects

### DIFF
--- a/source/annex/notes/design_principles.md
+++ b/source/annex/notes/design_principles.md
@@ -4,7 +4,7 @@ layout: spec
 tags: [annex, presentation-api, image-api]
 cssversion: 3
 redirect_from:
-  /annex/notes/design_patterns/
+ - /annex/notes/design_patterns/
 editors:
   - name: Michael Appleby
     ORCID: https://orcid.org/0000-0002-1266-298X

--- a/source/image/2.0/change-log.md
+++ b/source/image/2.0/change-log.md
@@ -10,7 +10,7 @@ minor: 0
 pre: final
 sitemap: false
 redirect_from:
-  /image/2.0/change-log.html
+ - /image/2.0/change-log.html
 ---
 
 This document is a companion to the [IIIF Image API Specification, Version 2.0][api]. It describes the significant changes to the API since [Version 1.1][api-11]. The changes are broken into three groups: [Breaking Changes][breaking-changes], i.e. those that are not backwards compatible from either a client or server perspective (or both) and mostly consists of new features; [Other Changes][other-changes], i.e. those that are backwards compatible; and [Deferred Changes][deferred-changes], i.e. those that will be made in a future iteration of the Image API.

--- a/source/image/2.0/compliance.md
+++ b/source/image/2.0/compliance.md
@@ -8,8 +8,6 @@ minor: 0
 patch: 0
 pre: final
 sitemap: false
-redirect_from:
-  /image/2.0/compliance.html
 ---
 
 ## Status of this Document

--- a/source/image/2.1/change-log-211.md
+++ b/source/image/2.1/change-log-211.md
@@ -8,7 +8,7 @@ minor: 1
 patch: 1
 pre: final
 redirect_from:
-  /image/2.1/change-log-211.html
+ - /image/2.1/change-log-211.html
 ---
 
 This document is a companion to the [IIIF Image API Specification, Version 2.1.1][image-api]. It describes the editorial changes to the API made in this patch release. The changes are all clarifications, typo corrections or to related documents that are not [semantically versioned][semver] such as inline examples and resources to manage transformation to and from the JSON-LD serialization.

--- a/source/image/2.1/change-log.md
+++ b/source/image/2.1/change-log.md
@@ -9,7 +9,7 @@ minor: 1
 # no patch
 pre: final
 redirect_from:
-  /image/2.1/change-log.html
+ - /image/2.1/change-log.html
 ---
 
 This document is a companion to the [IIIF Image API Specification, Version 2.1][api-21]. It describes the significant changes to the API since [Version 2.0][api-20]. The changes are broken into three groups: [Non-breaking Changes][non-breaking-changes], i.e. those that are backwards compatible from client or server perspectives; [Deprecations][deprecations] and [Deferred Changes][deferred-changes], i.e. those that will be made in a future iteration of the Image API.

--- a/source/image/2.1/compliance.md
+++ b/source/image/2.1/compliance.md
@@ -8,8 +8,7 @@ minor: 1
 patch: 0
 pre: final
 redirect_from:
-  /image/compliance.html
-  /image/2/compliance.html
+ - /image/2/compliance.html
 ---
 
 ## Status of this Document

--- a/source/image/2.1/index.md
+++ b/source/image/2.1/index.md
@@ -9,7 +9,7 @@ minor: 1
 patch: 1
 pre: final
 redirect_from:
-  /image/2/index.html
+ - /image/2/index.html
 editors:
   - name: Michael Appleby
     ORCID: https://orcid.org/0000-0002-1266-298X

--- a/source/image/3.0/change-log.md
+++ b/source/image/3.0/change-log.md
@@ -10,7 +10,7 @@ minor: 0
 patch: 0
 pre: final
 redirect_from:
-  /image/3.0/change-log-30.html
+ - /image/3.0/change-log-30.html
 ---
 
 This document is a companion to the [IIIF Image API Specification, Version 3.0][image30]. It describes the changes to the API specification made in this major release, including ones that are backwards incompatible with version 2.1.1, the previous version.

--- a/source/image/3.0/compliance.md
+++ b/source/image/3.0/compliance.md
@@ -9,8 +9,8 @@ patch: 0
 pre: final
 cssversion: 3
 redirect_from:
-  /image/compliance.html
-  /image/3/compliance.html
+ - /image/compliance.html
+ - /image/3/compliance.html
 ---
 
 ## Status of this Document

--- a/source/image/3.0/implementation.md
+++ b/source/image/3.0/implementation.md
@@ -3,7 +3,7 @@ title: "Image API 3.0 Implementation Notes"
 layout: spec
 cssversion: 2
 redirect_from:
-  /image/3/implementation.html
+ - /image/3/implementation.html
 ---
 
 ## 1. HTTP implementation

--- a/source/image/validator/download.html
+++ b/source/image/validator/download.html
@@ -5,7 +5,7 @@ id: technical-details
 categories: [pages]
 layout: page
 redirect_from:
-  /image/validator/download.html
+ - /image/validator/download.html
 ---
 
 <section class="wrapper">

--- a/source/image/validator/results.html
+++ b/source/image/validator/results.html
@@ -4,7 +4,7 @@ id: technical-details
 categories: [pages]
 layout: page
 redirect_from:
-  /image/validator/results.html
+ -  /image/validator/results.html
 breadcrumbs:
   - label: APIs & Documentation
     link: '{{ site.api_url }}/'

--- a/source/metadata/1.0/index.html
+++ b/source/metadata/1.0/index.html
@@ -1,10 +1,10 @@
 ---
 sitemap: false
 redirect_from:
-  /metadata/1/index.html
-  /metadata/index.html
-  /presentation/1/index.html
-  /presentation/1.0/index.html
+ - /metadata/1/index.html
+ - /metadata/index.html
+ - /presentation/1/index.html
+ - /presentation/1.0/index.html
 ---
 <!DOCTYPE html>
 <!--[if lt IE 7]>      <html lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->

--- a/source/presentation/2.0/change-log.md
+++ b/source/presentation/2.0/change-log.md
@@ -10,7 +10,7 @@ minor: 0
 pre: final
 sitemap: false
 redirect_from:
-  /presentation/2.0/change-log.html
+ - /presentation/2.0/change-log.html
 ---
 
 This document is a companion to the [IIIF Presentation API Specification, Version 2.0][prezi-api]. It describes the significant changes to the API since [Version 1.0][prezi-api-10]. The changes are broken into two groups: [Breaking Changes][breaking-changes], i.e. those that are not backwards compatible from either a client or server perspective (or both); [Other Changes][other-changes], i.e. those that are backwards compatible. A third section, [Deferred Proposals][deferred-proposals], lists proposals that have been discussed but did not make it into this version of the specification.

--- a/source/presentation/2.0/zones.md
+++ b/source/presentation/2.0/zones.md
@@ -9,7 +9,7 @@ patch: 0
 pre: draft1
 sitemap: false
 redirect_from:
-  /presentation/2.0/zones.html
+ - /presentation/2.0/zones.html
 ---
 
 ## Zones Notes

--- a/source/presentation/2.1/change-log-211.md
+++ b/source/presentation/2.1/change-log-211.md
@@ -9,7 +9,7 @@ minor: 1
 patch: 1
 pre: final
 redirect_from:
-  /presentation/2.1/change-log-211.html
+ - /presentation/2.1/change-log-211.html
 ---
 
 This document is a companion to the [IIIF Presentation API Specification, Version 2.1.1][prezi21]. It describes the editorial changes to the API specification made in this patch release, such as clarifications and typo corrections. It also describes corrections to related documents that are not [semantically versioned][notes-versioning], such as example resources and resources to manage transformation to and from the JSON-LD serialization.

--- a/source/presentation/2.1/change-log.md
+++ b/source/presentation/2.1/change-log.md
@@ -9,7 +9,7 @@ minor: 1
 # no patch
 pre: final
 redirect_from:
-  /presentation/2.1/change-log.html
+ - /presentation/2.1/change-log.html
 ---
 
 This document is a companion to the [IIIF Presentation API Specification, Version 2.1][prezi-api]. It describes the significant changes to the API since [Version 2.0][prezi-api-20] as well as editorial changes. The changes are all backwards compatible. A third section, [Deferred Proposals][deferred-proposals], lists proposals that have been discussed but did not make it into this version of the specification.

--- a/source/presentation/2.1/index.md
+++ b/source/presentation/2.1/index.md
@@ -7,7 +7,7 @@ minor: 1
 patch: 1
 pre: final
 redirect_from:
-  /presentation/2/index.html
+ - /presentation/2/index.html
 editors:
   - name: Michael Appleby
     ORCID: https://orcid.org/0000-0002-1266-298X

--- a/source/presentation/2.1/zones.md
+++ b/source/presentation/2.1/zones.md
@@ -8,7 +8,7 @@ minor: 1
 patch: 0
 pre: draft1
 redirect_from:
-  /presentation/2.1/zones.html
+ - /presentation/2.1/zones.html
 ---
 
 ## Zones Notes

--- a/source/presentation/3.0/change-log.md
+++ b/source/presentation/3.0/change-log.md
@@ -10,7 +10,7 @@ minor: 0
 patch: 0
 pre: final
 redirect_from:
- /presentation/3.0/change-log-30.html
+ - /presentation/3.0/change-log-30.html
 ---
 
 This document is a companion to the [IIIF Presentation API Specification, Version 3.0][prezi30]. It describes the changes to the API specification made in this major release, including ones that are backwards incompatible with [version 2.1.1][prezi21], the previous version.

--- a/source/presentation/usecases.md
+++ b/source/presentation/usecases.md
@@ -3,7 +3,7 @@ title: Presentation API Use Cases
 layout: spec
 tags: [presentation-api, use-cases]
 redirect_from:
-  /presentation/usecases.html
+ - /presentation/usecases.html
 ---
 
 ## Status of this Document

--- a/source/search/2.0/change-log.md
+++ b/source/search/2.0/change-log.md
@@ -10,7 +10,7 @@ minor: 0
 patch: 0
 pre: final
 redirect_from:
- /search/2.0/change-log-20.html
+ - /search/2.0/change-log-20.html
 ---
 
 This document is a companion to the [IIIF Content Search API Specification, Version 2.0][search20]. It describes the changes to the API specification made in this major release, including ones that are backwards incompatible with [version 1.0][search10], the previous version.


### PR DESCRIPTION
According to the [jekyll-redirect-from](https://github.com/jekyll/jekyll-redirect-from) you can specify redirects as:

```
redirect_from:
  - /post/123456789/my-amazing-post/
```

or 

```
redirect_from: /post/123456798/
```

but not:

```
redirect_from:
   /post/123456789/my-amazing-post/
```

So this fixes all of the redirects I could find. This causes problems on Windows as it tries to create directories with spaces in the filename and fails. On Mac it seems to just not create many of the redirect files. 