### PR TITLE
Add algorithm for auth 2 flow

### DIFF
--- a/source/_includes/links.md
+++ b/source/_includes/links.md
@@ -14,6 +14,7 @@
 [auth1]: {{ site.api_url | absolute_url }}/auth/1.0/ "IIIF Authentication API 1.0"
 [auth10]: {{ site.api_url | absolute_url }}/auth/1.0/ "IIIF Authentication API 1.0"
 [auth2-implementation-notes]: {{ site.api_url | absolute_url }}/auth/2.0/implementation/  "IIIF Authentication 2.0: Implementation Notes"
+[auth20-access-service]: {{ site.api_url | absolute_url }}/auth/2.0/#access-service "Access Service"
 [auth20-access-token-service]: {{ site.api_url | absolute_url }}/auth/2.0/#access-token-service "Access Token Service"
 [auth20-access-token-message-format]: {{ site.api_url | absolute_url }}/auth/2.0/#access-token-message-format "Access Token Message Format"
 [auth20-access-token-error-format]: {{ site.api_url | absolute_url }}/auth/2.0/#access-token-error-format "Access Token Error Format"

--- a/source/auth/2.0/index.md
+++ b/source/auth/2.0/index.md
@@ -486,26 +486,22 @@ Default additional text to render if an error occurs. If the access token servic
   {
     "id": "https://auth.example.org/probe",
     "type": "AuthProbeService2",
-    "service": [
+    // Access Service
+    "service" : [
       {
-        // Access Service
-        "service" : [
-          {
-            "id": "https://auth.example.org/login",
-            "type": "AuthAccessService2",
-            "profile": "active",
-            "label": { "en": [ "Login to Example Institution" ] },
-            // ... other recommended strings for user interface
+        "id": "https://auth.example.org/login",
+        "type": "AuthAccessService2",
+        "profile": "active",
+        "label": { "en": [ "Login to Example Institution" ] },
+        // ... other recommended strings for user interface
 
-            // Access Token Service
-            "service": [
-              {
-                "id": "https://auth.example.org/token",
-                "type": "AuthAccessTokenService2",
-                "errorHeading": { "en": [ "Something went wrong" ] },
-                "errorNote": { "en": [ "Could not get a token." ] },
-              }
-            ]
+        // Access Token Service
+        "service": [
+          {
+            "id": "https://auth.example.org/token",
+            "type": "AuthAccessTokenService2",
+            "errorHeading": { "en": [ "Something went wrong" ] },
+            "errorNote": { "en": [ "Could not get a token." ] },
           }
         ]
       }
@@ -716,6 +712,7 @@ The probe service is used by the client to understand whether the user has acces
 | -------------- | ---------- | ----------- |
 | `id`           | _REQUIRED_ | The URI of the probe service. |
 | `type`         | _REQUIRED_ | The value _MUST_ be the string `AuthProbeService2`. |
+| `service`      | _REQUIRED_ | References to one or more Access Services. |
 | `errorHeading` | _OPTIONAL_ | Default heading text to render if the probe indicates the user cannot access the resource. |
 | `errorNote`    | _OPTIONAL_ | Default additional text to render if the probe indicates the user cannot access the resource. |
 
@@ -734,6 +731,10 @@ Default heading text to render if the probe indicates the user cannot access the
 #### errorNote
 
 Default additional text to render if the probe indicates the user cannot access the resource. If the probe response `status` property indicates access would not be granted, the `note` property of the probe response _MUST_ be used instead if supplied. If present, `errorHeading` _MUST_ also be present.
+
+#### service
+
+The value _MUST_ be an array of JSON objects. Each object _MUST_ have the `id` and `type` properties. The `service` array _MUST_ contain one or more [access services][auth20-access-token-service].
 
 
 ### 5.1. Probe Service Request
@@ -908,7 +909,70 @@ If possible, the server _SHOULD_ invalidate any authorizing aspects it controls 
   </tbody>
 </table>
 
+### 7.1. Authorization Flow Algorithm
 
+As specified above, a resource _MAY_ have multiple Probe services, and a Probe service _MAY_ have multiple Access services. The same Access service (e.g., a login page) _MAY_ be shared by multiple Probe services. Each Access service _MUST_ have one associated Token service, and _MAY_ have one associated Logout service. While multiple Probe services per resource and multiple Access services per Probe service are not likely to be common, clients _SHOULD_ be able to interact with multiple services.
+
+A Token service is _associated with_ a Probe service if that Probe service's `service` property includes an Access service whose `service` property includes the Token service (i.e., the Probe service is the grandparent of the Token service).
+
+Given a resource that has a set of Probe services `P` with at least one member:
+
+For each Probe service `ps` in the set of Probe services `P`  
+  Make a GET request to `ps` with no token
+  In the Probe Service response:
+    If `status` = 200, display the resource (end)
+    If `status` = 30x and `location` is not empty, display the resource at `location` (end)
+    If `status` = 401 and `substitute` is not empty, display the resource at `substitute` (goto `99`)
+
+  Let `T` be the set of non-expired tokens acquired from token services _associated with_ `ps`
+  For each token `t` in `T`
+    Make a GET request to `ps` with a header carrying Bearer token `t`
+    In the Probe Service response:
+      If `status` = 200, display the resource (end)
+      If `status` = 30x and `location` is not empty, display the resource at `location` (end)
+      If `status` = 401 and `substitute` is not empty, display the resource at `substitute` (goto `99`)
+  
+  (`99`) Let `A` be the set of Access services included in the `services` property of `ps`
+    For each Access service `as` in `A` where `as.profile` == `external`
+      Open the token service `ts` associated with `as`
+      Receive postMessage response `pm` from `ts`
+      If `pm` has `accessToken` `t`
+        Make a GET request to `ps` with a header carrying Bearer token `t`
+        ... (same)
+    For each Access service `as` in `A` where `as.profile` == `kiosk`
+      Open `as`
+      Wait for window to close
+        Open the token service `ts` associated with `as`
+        Receive postMessage response `pm` from `ts`
+        If `pm` has `accessToken` `t`
+          Make a GET request to `ps` with a header carrying Bearer token `t`
+          ... (same)
+    For each Access service `as` in `A` where `as.profile` == `active`
+      Display user interface (using strings) - need algo for string selection
+      Accept user call to action
+      Open `as`
+      Wait for window to close
+        Open the token service `ts` associated with `as`
+        Receive postMessage response `pm` from `ts`
+        If `pm` has `accessToken` `t`
+          Make a GET request to `ps` with a header carrying Bearer token `t`
+          ... (same)
+No display possible
+
+
+For each Probe service `ps` in the set of Probe services `P`
+
+
+
+* Given a set of Probe services (`P`) and a set of Access services (`A`) associated with the access controlled resource,
+* For each access service (`as`) in `A`,
+  * If the user has already authenticated to `as` and the client has a token (`t`) from a related Access Token service,
+    * For each probe service (`ps`) in `P`,
+      * Make a request to `ps` with token `t` to get the response (`resp`)
+      * If the `status` property of `resp` is `200`, then the user can retrieve the access controlled resource, so exit with success
+      * If the `status` property of `resp` is `401`, ...
+
+<!-- 
 Browser-based clients will perform the following workflow in order to access access controlled resources:
 
 * The client requests the Probe Service and checks the status code of the response.
@@ -928,6 +992,8 @@ Browser-based clients will perform the following workflow in order to access acc
 * After the Access Token service has been requested, if the client receives a token, it tries the Probe Service again with this newly acquired token.
   * If the client instead receives an error, it returns to look for further authentication services to interact with.
   * If there are no further authentication services, then the user does not have the credentials to interact with any of the Content Resource versions, and the client cannot display anything.
+-->
+
 
 ### 7.1 Tiered Access
 {: #tiered-access}

--- a/source/auth/2.0/index.md
+++ b/source/auth/2.0/index.md
@@ -180,7 +180,7 @@ A user wishes to see an access-controlled resource such as an image, video, PDF,
     <tr>
       <td>
         <img src="{{ site.api_url | absolute_url }}/assets/images/auth2-sequence.png" alt="Authorization Flow Service Interactions diagram" class="fullPct" />
-        <p><strong>1</strong> Client Interactions With Authorization Flow Services </p>
+        <p>Client Interactions With Authorization Flow Services</p>
       </td>
     </tr>
   </tbody>
@@ -903,7 +903,7 @@ If possible, the server _SHOULD_ invalidate any authorizing aspects it controls 
     <tr>
       <td>
         <img src="{{ site.api_url | absolute_url }}/assets/images/auth2-client-flow.png" alt="Client Authorization Flow" class="fullPct" />
-        <p><strong>2</strong> Client Authorization Flow Workflow</p>
+        <p>Client Authorization Flow Workflow</p>
       </td>
     </tr>
   </tbody>

--- a/source/auth/2.0/index.md
+++ b/source/auth/2.0/index.md
@@ -241,15 +241,6 @@ There are three interaction patterns by which the client can use the access serv
 
 The `active` profile requires additional properties in the service description, defined in the [Active Interaction Pattern][auth20-active-interaction-pattern] section below.
 
-<!-- TODO 
-
-The text needs to describe the order the services are tried - external, kiosk, active
-
-This is only in the diagram and algorithm at the moment.
-
-
--->
-
 ```json-doc
 { "profile": "active" }
 ```
@@ -293,7 +284,7 @@ The server _MAY_ use this information to validate the origin supplied in subsequ
 
 ### 3.3. Interaction Patterns
 
-There are three distinct interaction patterns, identified by the `profile` property. These enable different styles of user, client and server interaction.
+The three distinct interaction patterns identified by the `profile` property enable different styles of user, client and server interaction. If more than one Access Service is available, the client _SHOULD_ interact with them in the order `external`, `kiosk`, `active`. The client _SHOULD_ stop processing Access Services once it determines that the user has access to the resource. This order ensures that access is obtained with the minimum of user interaction.
 
 #### 3.3.1 Active Interaction Pattern
 {: #active-interaction-pattern}
@@ -346,7 +337,7 @@ Heading text to be shown with the user interface element that opens the access s
 Additional text to be shown with the user interface element that opens the access service. If present, it _MUST_ be shown to the user. The value of the property _MUST_ be a JSON object as described in the [Language of Property Values][prezi3-languages] section of the Presentation API.
 
 ```json-doc
-{ "note": { "en": [ "Example Institution requires that you log in with your example account to view this content." ] }
+{ "note": { "en": [ "Example Institution requires that you log in with your example account to view this content." ] } }
 ```
 
 #### Complete Service Description

--- a/source/auth/2.0/index.md
+++ b/source/auth/2.0/index.md
@@ -917,56 +917,101 @@ A token service is _associated with_ a probe service if that probe service's `se
 
 Given a resource that has a set of probe services `P` with at least one member:
 
-For each probe service `ps` in the set of probe services `P`  
-  Make a GET request to `ps` with no token
-  In the probe service response:
-    If `status` = 200, display the resource (end)
-    If `status` = 30x and `location` is not empty, display the resource at `location` (end)
-    If `status` = 401 and `substitute` is not empty, display the resource at `substitute` (goto ACCESS_SERVICE)
-
-  Let `T` be the set of non-expired tokens acquired from token services _associated with_ `ps`
-  For each token `t` in `T`
-    Make a GET request to `ps` with a header carrying Bearer token `t`
-    In the probe service response:
-      If `status` = 200, display the resource (end)
-      If `status` = 30x and `location` is not empty, display the resource at `location` (end)
-      If `status` = 401 and `substitute` is not empty, display the resource at `substitute` (goto ACCESS_SERVICE)
-  
-  ACCESS_SERVICE: Let `A` be the set of access services included in the `services` property of `ps`
-    For each untried access service `as` in `A` where `as.profile` == `external`:
-      Open the token service `ts` associated with `as`
-      Receive postMessage response `pm` from `ts`
-      If `pm` has `accessToken` `t`
-        Make a GET request to `ps` with a header carrying Bearer token `t`
-        In the probe service response:
-          If `status` = 200, display the resource (end)
-          If `status` = 30x and `location` is not empty, display the resource at `location` (end)
-          If `status` = 401 and `substitute` is not empty, display the resource at `substitute` (goto ACCESS_SERVICE)
-    For each untried access service `as` in `A` where `as.profile` == `kiosk`
-      Open `as`
-      Wait for window to close
-        Open the token service `ts` associated with `as`
-        Receive postMessage response `pm` from `ts`
-        If `pm` has `accessToken` `t`
-          Make a GET request to `ps` with a header carrying Bearer token `t`
-          In the probe service response:
-            If `status` = 200, display the resource (end)
-            If `status` = 30x and `location` is not empty, display the resource at `location` (end)
-            If `status` = 401 and `substitute` is not empty, display the resource at `substitute` (goto ACCESS_SERVICE)
-    For each untried access service `as` in `A` where `as.profile` == `active`
-      Display user interface using available strings
-      Accept user call to action to open the access service
-      Open `as`
-      Wait for window to close
-        Open the token service `ts` associated with `as`
-        Receive postMessage response `pm` from `ts`
-        If `pm` has `accessToken` `t`
-          Make a GET request to `ps` with a header carrying Bearer token `t`
-            In the probe service response:
-              If `status` = 200, display the resource (end)
-              If `status` = 30x and `location` is not empty, display the resource at `location` (end)
-              If `status` = 401 and `substitute` is not empty, display the resource at `substitute` (goto ACCESS_SERVICE)
-No display possible
+<ul>
+  <li>For each probe service <code class="highlighter-rouge">ps</code> in the set of probe services <code class="highlighter-rouge">P</code>
+    <ul>
+      <li>Make a GET request to <code class="highlighter-rouge">ps</code> with no token</li>
+      <li>In the probe service response
+        <ul>
+          <li>If <code class="highlighter-rouge">status</code> = 200, display the resource (end)</li>
+          <li>If <code class="highlighter-rouge">status</code> = 30x and <code class="highlighter-rouge">location</code> is not empty, display the resource at <code class="highlighter-rouge">location</code> (end)</li>
+          <li>If <code class="highlighter-rouge">status</code> = 401 and <code class="highlighter-rouge">substitute</code> is not empty, display the resource at <code class="highlighter-rouge">substitute</code> (goto ACCESS_SERVICE)</li>
+        </ul>
+      </li>
+      <li>Let <code class="highlighter-rouge">T</code> be the set of non-expired tokens acquired from token services _associated with_ <code class="highlighter-rouge">ps</code></li>
+      <li>For each token <code class="highlighter-rouge">t</code> in <code class="highlighter-rouge">T</code>
+        <ul>
+          <li>Make a GET request to <code class="highlighter-rouge">ps</code> with a header carrying Bearer token <code class="highlighter-rouge">t</code></li>
+          <li>In the probe service response:
+            <ul>
+              <li>If <code class="highlighter-rouge">status</code> = 200, display the resource (end)</li>
+              <li>If <code class="highlighter-rouge">status</code> = 30x and <code class="highlighter-rouge">location</code> is not empty, display the resource at <code class="highlighter-rouge">location</code> (end)</li>
+              <li>If <code class="highlighter-rouge">status</code> = 401 and <code class="highlighter-rouge">substitute</code> is not empty, display the resource at <code class="highlighter-rouge">substitute</code> (goto ACCESS_SERVICE)</li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li>ACCESS_SERVICE: Let <code class="highlighter-rouge">A</code> be the set of access services included in the <code class="highlighter-rouge">services</code> property of <code class="highlighter-rouge">ps</code></li>
+      <li>For each untried access service <code class="highlighter-rouge">as</code> in <code class="highlighter-rouge">A</code> where <code class="highlighter-rouge">as.profile</code> == <code class="highlighter-rouge">external</code>
+        <ul>
+          <li>Open the token service <code class="highlighter-rouge">ts</code> associated with <code class="highlighter-rouge">as</code></li>
+          <li>Receive postMessage response <code class="highlighter-rouge">pm</code> from <code class="highlighter-rouge">ts</code></li>
+          <li>If <code class="highlighter-rouge">pm</code> has <code class="highlighter-rouge">accessToken</code> <code class="highlighter-rouge">t</code>
+            <ul>
+              <li>Make a GET request to <code class="highlighter-rouge">ps</code> with a header carrying Bearer token <code class="highlighter-rouge">t</code></li>
+              <li>In the probe service response
+                <ul>
+                  <li>If <code class="highlighter-rouge">status</code> = 200, display the resource (end)</li>
+                  <li>If <code class="highlighter-rouge">status</code> = 30x and <code class="highlighter-rouge">location</code> is not empty, display the resource at <code class="highlighter-rouge">location</code> (end) </li>
+                  <li>If <code class="highlighter-rouge">status</code> = 401 and <code class="highlighter-rouge">substitute</code> is not empty, display the resource at <code class="highlighter-rouge">substitute</code> (goto ACCESS_SERVICE)</li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li>For each untried access service <code class="highlighter-rouge">as</code> in <code class="highlighter-rouge">A</code> where <code class="highlighter-rouge">as.profile</code> == <code class="highlighter-rouge">kiosk</code>
+        <ul>
+          <li>Open <code class="highlighter-rouge">as</code></li>
+          <li>Wait for window to close
+            <ul>
+              <li>Open the token service <code class="highlighter-rouge">ts</code> associated with <code class="highlighter-rouge">as</code></li>
+              <li>Receive postMessage response <code class="highlighter-rouge">pm</code> from <code class="highlighter-rouge">ts</code></li>
+              <li>If <code class="highlighter-rouge">pm</code> has <code class="highlighter-rouge">accessToken</code> <code class="highlighter-rouge">t</code>
+                <ul>
+                  <li>Make a GET request to <code class="highlighter-rouge">ps</code> with a header carrying Bearer token <code class="highlighter-rouge">t</code></li>
+                  <li>In the probe service response:
+                    <ul>
+                      <li>If <code class="highlighter-rouge">status</code> = 200, display the resource (end)</li>
+                      <li>If <code class="highlighter-rouge">status</code> = 30x and <code class="highlighter-rouge">location</code> is not empty, display the resource at <code class="highlighter-rouge">location</code> (end)</li>
+                      <li>If <code class="highlighter-rouge">status</code> = 401 and <code class="highlighter-rouge">substitute</code> is not empty, display the resource at <code class="highlighter-rouge">substitute</code> (goto ACCESS_SERVICE)</li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li>For each untried access service <code class="highlighter-rouge">as</code> in <code class="highlighter-rouge">A</code> where <code class="highlighter-rouge">as.profile</code> == <code class="highlighter-rouge">active</code>
+        <ul>
+          <li>Display user interface using available strings</li>
+          <li>Accept user call to action to open the access service</li>
+          <li>Open <code class="highlighter-rouge">as</code></li>
+          <li>Wait for window to close
+            <ul>
+              <li>Open the token service <code class="highlighter-rouge">ts</code> associated with <code class="highlighter-rouge">as</code></li>
+              <li>Receive postMessage response <code class="highlighter-rouge">pm</code> from <code class="highlighter-rouge">ts</code></li>
+              <li>If <code class="highlighter-rouge">pm</code> has <code class="highlighter-rouge">accessToken</code> <code class="highlighter-rouge">t</code>
+                <ul>
+                  <li>Make a GET request to <code class="highlighter-rouge">ps</code> with a header carrying Bearer token <code class="highlighter-rouge">t</code></li>
+                  <li>In the probe service response
+                    <ul>
+                      <li>If <code class="highlighter-rouge">status</code> = 200, display the resource (end)</li>
+                      <li>If <code class="highlighter-rouge">status</code> = 30x and <code class="highlighter-rouge">location</code> is not empty, display the resource at <code class="highlighter-rouge">location</code> (end)</li>
+                      <li>If <code class="highlighter-rouge">status</code> = 401 and <code class="highlighter-rouge">substitute</code> is not empty, display the resource at <code class="highlighter-rouge">substitute</code> (goto ACCESS_SERVICE)</li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  <li>No display possible</li>
+</ul>
 
 
 ### 7.1 Tiered Access

--- a/source/auth/2.0/index.md
+++ b/source/auth/2.0/index.md
@@ -911,15 +911,15 @@ If possible, the server _SHOULD_ invalidate any authorizing aspects it controls 
 
 ### 7.1. Authorization Flow Algorithm
 
-A resource may have multiple Probe services, and a Probe service may have multiple Access services. The same Access service (e.g., a login page) may be shared by multiple Probe services. Each Access service must have one associated Token service, and may have one associated Logout service. While multiple Probe services per resource and multiple Access services per Probe service are not likely to be common, clients should be able to interact with multiple services.
+A resource may have multiple probe services, and a probe service may have multiple Access services. The same access service (e.g., a login page) may be shared by multiple probe services. Each access service must have one associated token service, and may have one associated Logout service. While multiple probe services per resource and multiple access services per probe service are not likely to be common, clients should be able to interact with multiple services.
 
-A Token service is _associated with_ a Probe service if that Probe service's `service` property includes an Access service whose `service` property includes the Token service (i.e., the Probe service is the grandparent of the Token service).
+A token service is _associated with_ a probe service if that probe service's `service` property includes an access service whose `service` property includes the token service (i.e., the probe service is the grandparent of the token service).
 
-Given a resource that has a set of Probe services `P` with at least one member:
+Given a resource that has a set of probe services `P` with at least one member:
 
-For each Probe service `ps` in the set of Probe services `P`  
+For each probe service `ps` in the set of probe services `P`  
   Make a GET request to `ps` with no token
-  In the Probe Service response:
+  In the probe service response:
     If `status` = 200, display the resource (end)
     If `status` = 30x and `location` is not empty, display the resource at `location` (end)
     If `status` = 401 and `substitute` is not empty, display the resource at `substitute` (goto ACCESS_SERVICE)
@@ -927,42 +927,42 @@ For each Probe service `ps` in the set of Probe services `P`
   Let `T` be the set of non-expired tokens acquired from token services _associated with_ `ps`
   For each token `t` in `T`
     Make a GET request to `ps` with a header carrying Bearer token `t`
-    In the Probe Service response:
+    In the probe service response:
       If `status` = 200, display the resource (end)
       If `status` = 30x and `location` is not empty, display the resource at `location` (end)
       If `status` = 401 and `substitute` is not empty, display the resource at `substitute` (goto ACCESS_SERVICE)
   
-  ACCESS_SERVICE: Let `A` be the set of Access services included in the `services` property of `ps`
-    For each untried Access service `as` in `A` where `as.profile` == `external`:
+  ACCESS_SERVICE: Let `A` be the set of access services included in the `services` property of `ps`
+    For each untried access service `as` in `A` where `as.profile` == `external`:
       Open the token service `ts` associated with `as`
       Receive postMessage response `pm` from `ts`
       If `pm` has `accessToken` `t`
         Make a GET request to `ps` with a header carrying Bearer token `t`
-        In the Probe Service response:
+        In the probe service response:
           If `status` = 200, display the resource (end)
           If `status` = 30x and `location` is not empty, display the resource at `location` (end)
           If `status` = 401 and `substitute` is not empty, display the resource at `substitute` (goto ACCESS_SERVICE)
-    For each untried Access service `as` in `A` where `as.profile` == `kiosk`
+    For each untried access service `as` in `A` where `as.profile` == `kiosk`
       Open `as`
       Wait for window to close
         Open the token service `ts` associated with `as`
         Receive postMessage response `pm` from `ts`
         If `pm` has `accessToken` `t`
           Make a GET request to `ps` with a header carrying Bearer token `t`
-          In the Probe Service response:
+          In the probe service response:
             If `status` = 200, display the resource (end)
             If `status` = 30x and `location` is not empty, display the resource at `location` (end)
             If `status` = 401 and `substitute` is not empty, display the resource at `substitute` (goto ACCESS_SERVICE)
-    For each untried Access service `as` in `A` where `as.profile` == `active`
+    For each untried access service `as` in `A` where `as.profile` == `active`
       Display user interface using available strings
-      Accept user call to action to open the Access Service
+      Accept user call to action to open the access service
       Open `as`
       Wait for window to close
         Open the token service `ts` associated with `as`
         Receive postMessage response `pm` from `ts`
         If `pm` has `accessToken` `t`
           Make a GET request to `ps` with a header carrying Bearer token `t`
-            In the Probe Service response:
+            In the probe service response:
               If `status` = 200, display the resource (end)
               If `status` = 30x and `location` is not empty, display the resource at `location` (end)
               If `status` = 401 and `substitute` is not empty, display the resource at `substitute` (goto ACCESS_SERVICE)


### PR DESCRIPTION
Updates to the spec as discussed on Auth call 28 Feb 2023

 - Introduce required order in which access services _SHOULD_ be tried (`external`, `kiosk`, `active`), before we get to the flow diagram.
 - Add an _algorithm_ - while this is still in review I haven't formatted the markdown into a nested list, so it only makes sense when you view the markdown source. I'll decorate this with nested lists markup (probably, rather than markdown) once we agree it looks OK.
 - Fix a couple of JSON errors
 - Remove some unnecessary repetitive text

