### PR TITLE
Temporarily disabling internal link checking

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,10 +32,10 @@ jobs: # A workflow run is made up of one or more jobs that can run sequentially 
       run: bundle exec rake build:preview
     - name: Test html
       run: bundle exec rake test:html
-    - name: Test internal links
-      run: bundle exec rake test:links:internal
-    - name: Test *iiif.io* links
-      run: bundle exec rake test:links:iiif
+#    - name: Test internal links
+#      run: bundle exec rake test:links:internal
+#    - name: Test *iiif.io* links
+#      run: bundle exec rake test:links:iiif
     - name: Spec tests
       run: bundle exec rake api:spec
     - name: Create GitHub deployment # Deploy to Preview site


### PR DESCRIPTION
I can disable other tests if it would be helpful but this leaves the HTML check and other checks but disables internal link checking. 

Note it doesn't stop the external link checker which doesn't stop the deploy to preview and can be ignored. 