### PR TITLE
Rationalise ### headings in P4 index

### DIFF
--- a/source/presentation/4.0/index.md
+++ b/source/presentation/4.0/index.md
@@ -53,33 +53,37 @@ __Previous Version:__ [3.0][prezi30]
 
 ## Introduction
 
-Presentation, the clue is in the name
+The purpose of the IIIF Presentation API specification is to provide a [model](model) and JSON serialization format of that model. 
 
+It provides a document format - the IIIF Manifest - for cultural heritage organizations (and anyone else) to publish standardized, interoperable objects. This allows compatible software such as viewers and annotation tools to load and present complex digital objects on the web. 
 
-(non-exhaustive) List of use cases
+The specification is solely concerned with presentation - providing enough information to render an object in compatible software, and leaving the meaning of the object to external descriptive metadata standards.
 
-1. Artwork
-2. Book
-3. 45 Single
-4. Movie
-5. 3D 1 (Single model at 0,0,0 in Scene with ambient Light and Camera)
-6. 3D 2 (Complex stuff)
-7. Periodical
-8. 3D 3 (storytelling)
-9. Manuscript (integration)
+_Presentation, the clue is in the name_
 
+This specification is presented in two parts. This document acts as an introduction to the specification through a set of typical (but non-exhaustive) use cases. The model [model](model) provides the formal specification of the terms used in this introduction.
 
-see Terminology at the end
+### IIIF Use cases 
 
-Mention model.md
+1. **Artwork** - a IIIF Manifest that represents a painting, comprising a single image and accompanying display information. 
+2. **Book** - a IIIF Manifest that represents a digitized bound volume made up many separate images in order. The IIIF model provides structural elements to indicate the chapters. The text of the book is made available in machine-readable form as Web Annotations.
+3. **45 Single** - a IIIF Manifest that represents the digitized audio from the two sides of a vinyl 7 inch record.
+4. **Movie** - a IIIF Manifest that represents the digitized video of a film. A transcript of the audio is provided as Web Annotations, and additional machine-readable files provide subtitles and captions.
+5. **Simple 3D Model** - a IIIF Manifest that publishes a single 3D model.
+6. **Complex Scene** - a IIIF Manifest that publishes a complex 3D scene comprising multiple models, lights and cameras.
+7. **Periodical** - a IIIF Collection that provides multiple IIIF child IIIF Collections and Manifests, representing the publication run of a newspaper over many years. The IIIF model provides structural elements to indicate individual articles and other elements. 
+8. **Storytelling in 3D** - a IIIF Manifest that defines a sequence of states in a complex scene for the purposes of guiding a user through a particular experience.
+9. **Manuscript** - (integration)
 
-Mention cookbook
+These use case were chosen as a broad sample to introduce IIIF Concepts. Many more use cases are provided as recipes in the [IIIF Cookbook](link).
 
 
 Consider diagrams
 
 
 ## Foundations
+
+(needs updating)
 
 <p style="float: right">
   <img src="{{ site.api_url | absolute_url }}/assets/images/data-model.png" alt="Data Model" width="400"><br/>
@@ -96,8 +100,19 @@ Manifests have descriptive, technical and linking properties. The required prope
 
 (👀) [Model Documentation](model/#manifest)
 
-```
-Manifest JSON
+
+```json
+{
+  "@context": "http://iiif.io/api/presentation/4/context.json",
+  "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "en": [ "Single Image Example" ]
+  },
+  "items": [
+    // A list of Containers
+  ]
+}
 ```
 
 
@@ -122,6 +137,7 @@ A Container that represents a bounded, two-dimensional space, optionally with a 
 
 Canvases have two additional required properties: `height` and `width`, which give the spatial extent as unitless integers. Canvases may also have the `duration` property in the same manner as Timelines.
 
+
 #### Scene
 
 A Container that represents a boundless three-dimensional space, optionally with a bounded temporal range. Scenes are typically used for rendering 3D models, and can additionally have Cameras and Lights.
@@ -131,14 +147,111 @@ Scenes may also have the `duration` property in the same manner as Timelines.
 (👀) [Model Documentation](model/#containers)
 
 ```json
-Manifest JSON with a Timeline, a Canvas and a Scene
+{
+  "@context": "http://iiif.io/api/presentation/4/context.json",
+  "id": "https://iiif.io/api/presentation/examples/manifest-with-containers",
+  "type": "Manifest",
+  "label": {
+    "en": [ "A Manifest with all three types of Container" ]
+  },
+  "items": [
+    {
+      "id": "https://iiif.io/api/presentation/examples/manifest-with-containers/timeline",
+      "type": "Timeline",
+      "duration": 32.76,
+      "items": [
+        {
+          "id": "https://iiif.io/api/presentation/examples/manifest-with-containers/page/p1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/presentation/examples/manifest-with-containers/annotation/t1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/presentation/example-content-resources/audio/clip.mp3",
+                "type": "Audio",
+                "format": "audio/mp3",
+                "duration": 32.76,
+              },
+              "target": "https://iiif.io/api/presentation/examples/manifest-with-containers/timeline"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.io/api/presentation/examples/manifest-with-containers/canvas",
+      "type": "Canvas",
+      "width": 12000,
+      "height": 9000,
+      "items": [
+        {
+          "id": "https://iiif.io/api/presentation/examples/manifest-with-containers/page/p2",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/presentation/examples/manifest-with-containers/annotation/c1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/presentation/example-content-resources/image/painting.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "width": 4000,
+                "height": 3000
+              },
+              "target": "https://iiif.io/api/presentation/examples/manifest-with-containers/canvas"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.io/api/presentation/examples/manifest-with-containers/scene",
+      "type": "Scene",
+      "items": [
+        {
+          "id": "https://iiif.io/api/presentation/examples/manifest-with-containers/page/p3",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/presentation/examples/manifest-with-containers/annotation/s1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/presentation/example-content-resources/models/astronaut.glb",
+                "type": "Model",
+                "format": "model/gltf-binary"
+              },
+              "target": "https://iiif.io/api/presentation/examples/manifest-with-containers/scene"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
 ```
+
+The above Manifest has three Containers, one of each type. While contrived, it is still valid and the expected user experience would be for a viewer to begin on the Timeline Container, presenting UI for the user to play the audio. The viewer would also present navigation elements to move to the next Container (the Canvas) or otherwise navigate the available Content Containers. Usually, even when a Manifest has a large number of Containers in its `items` property, they are of the same type (e.g., a 100 page book is modelled as a Manifest with 100 Canvases, each bearing an image of one page). But it is not a requirement that all Containers in a Manifest must be of the same type.
+
+In each of the three Containers, an **Annotation** links the Container to a Content Resource. The Content Resource is _painted_ into the Container by an Annotation whose `target` property is the `id` of the Container. In all three simple cases here the `target` property is the the `id` of the Container with no further qualification. 
+
+
 
 ### Annotations
 
 IIIF uses the concept of _Annotation_ to link resources together from around the web. This specification uses a World Wide Web Consortium (W3C) standard for this called the [Web Annotation Data Model][org-web-anno]. This is a structured linking mechanism useful for making comments about Content Resources, but IIIF's primary use of it is to associate the images, audio and other Content Resources with their Containers for presentation.
 
 Different uses of Annotation are distinguished through their `motivation` property. This specification defines a value for `motivation` called `painting` for associating Content Resources with Containers, which this specification calls a Painting Annotation. The verb "paint" is also used to refer to the associating of a Content Resource with a Container by a Painting Annotation. This is from the notion of painting onto a canvas, a metaphor borrowed from art and used for image-based digital applications, and expanded by IIIF into "painting" any Content Resource into a Container of any number of dimensions.
+
+In the example Manifest above the first Container is a Timeline. One content resource, an MP3 file, is associated with the Timeline via a Painting Annotation for its entire duration. Typically the duration of the Timeline matches the duration of its content. This is the simplest time-based use case. The `target` property of the Painting Annotation is the whole Timeline, because it is simply the `id` of the Timeline without further qualification. In this simple case, playing the Timeline is the same as playing the MP3.
+
+The second Container is a Canvas, representing a 2D surface. In this case the Canvas represents an artwork, and there is no duration property. The content resource, a JPEG image of the artwork, is associated with the Canvas via a Painting Annotation. The unit integer coordinates of the Canvas (12000 x 9000) are not the same as the pixel dimensions of the JPEG image (4000 x 3000), but they are proportional - the Canvas has a 4:3 landscape aspect ratio, and so does the JPEG image. The `target` property of the Annotation is the Canvas `id`, unqualified by any particular region; this is taken to mean the content (the image) should fill the Canvas completely. As the Canvas and the image are the same aspect ratio, no distortion will occur. This approach allows the current image to be replaced by a higher resolution image in future, on the same Canvas. The Canvas dimensions establish a coordinate system for _painting annotations_ and other kinds of annotation that link content with the Canvas; they are not pixels of images.
+
+The third Container is a Scene. Unlike a Canvas, it is not a bounded spatial extent, but may be a bounded temporal extent if it has the optional duration property. It still establishes a coordinate space (x, y, z) but doesn't need any spatial properties to do so as it is always the same, infinite unbounded space. The Annotation paints the astronaut model into the Scene. As no further qualification is given, the astronaut model is placed at the (0,0,0) origin of the Scene. Later examples will show how to control the lighting and camera position(s) and properties, but this is not required; a IIIF viewer is expected to supply ambient light and a default camera position in the absence of specific values.
+
 
 The same linking mechanism is also used in IIIF with other motivations for transcriptions, commentary, tags and other content. This provides a single, unified method for aligning content, and provides a standards-based framework for referencing parts of resources. As Annotations can be added later, it promotes a distributed system in which further content such as commentary can be aligned with the objects published on the web.
 
@@ -148,8 +261,34 @@ The relationship between a Container and a painting annotation is not direct. An
 
 (👀) [Model Documentation](model/#annotations)
 
-```
-JSON of painting anno - image to canvas
+```json
+{
+  "id": "https://iiif.io/api/presentation/examples/manifest-with-containers/canvas",
+  "type": "Canvas",
+  "width": 12000,
+  "height": 9000,
+  "items": [
+    {
+      "id": "https://iiif.io/api/presentation/examples/manifest-with-containers/page/p2",
+      "type": "AnnotationPage",
+      "items": [
+        {
+          "id": "https://iiif.io/api/presentation/examples/manifest-with-containers/annotation/c1",
+          "type": "Annotation",
+          "motivation": "painting",
+          "body": {
+            "id": "https://iiif.io/api/presentation/example-content-resources/image/painting.jpg",
+            "type": "Image",
+            "format": "image/jpeg",
+            "width": 4000,
+            "height": 3000
+          },
+          "target": "https://iiif.io/api/presentation/examples/manifest-with-containers/canvas"
+        }
+      ]
+    }
+  ]
+}
 ```
 
 ### Content Resources
@@ -158,6 +297,7 @@ Content Resources are external web resources, including images, video, audio, 3D
 
 The required properties of Content Resources are `id` and `type`. Other commonly used properties include `format`, and `width`, `height` and `duration` as appropriate to the Content Resource format.
 
+The Containers example also demonstrates that if you have existing content resources with web URIs - images, audio, video and models - you can quite easily publish IIIF Manifests for them by constructing the appropriate JSON around them and publishing the JSON documents. This requires careful consideration of the URI schemes for `id` properties of Containers and their Manifests to ensure they remain referenceable in the future. The choice of Timeline or Canvas dimensions (duration, width, height) can usually be derived simply from the content; the same duration as the audio or video, and the same unit Canvas dimensions as the image or video pixel dimensions, with the caveat that you should avoid low values for `width` and `height` (ref model).
 
 #### Containers as Content Resources
 
@@ -173,9 +313,22 @@ Parts of resources on the Web are identified using URIs with a fragment componen
 
 There are different types of fragment based on the format of the resource. The most commonly used type in IIIF is the W3C's Media Fragments specification, as it can define a temporal and 2D spatial region.
 
+```json
+{
+  "id": "https://iiif.io/api/presentation/examples/manifest-with-containers/comments/c1",
+  "type": "Annotation",
+  "motivation": "commenting",
+  "body": {
+    "type": "TextualBody",
+    "value": "Koto with a cover being carried",
+    "language": "en",
+    "format": "text/plain"
+  },
+  "target": "https://iiif.io/api/presentation/examples/manifest-with-containers/canvas#xywh=6050,3220,925,1250"
+}
 ```
-comment annotation about part of the previous example's Canvas using #Fragment
-```
+
+Here the Canvas `id` from the earlier example is still the `target` of an Annotation, but it has been qualified to a specific region of that Canvas by a Fragment Selector `#xywh=6050,3220,925,1250`. Note that the x, y, w, and h are in the Canvas coordinate space, not the pixel dimensions space. This annotation has no knowledge of or dependency on the particular image we painted onto the Canvas; we could replace that image with one of a different, higher resolution without affecting this annotation or the region of the Canvas it targets.
 
 
 ##### Specific Resource
@@ -186,8 +339,29 @@ Several different classes of Selector are used in IIIF, including an alternative
 
 The required properties of Specific Resources are `id`, `type`, and `source`. Other commonly used properties include `selector`, `transform`, and `scope`.
 
-```
-comment annotation about part of the previous example's Canvas using FragmentSelector
+```json
+{
+  "id": "https://iiif.io/api/presentation/examples/manifest-with-containers/comments/c1",
+  "type": "Annotation",
+  "motivation": "commenting",
+  "body": {
+    "type": "TextualBody",
+    "value": "Koto with a cover being carried",
+    "language": "en",
+    "format": "text/plain"
+  },
+  "target": {
+    "type": "SpecificResource",
+    "source":  {
+      "id": "https://iiif.io/api/presentation/examples/manifest-with-containers/canvas",
+      "type": "Canvas"
+    },
+    "selector": {
+      "type": "FragmentSelector",
+      "value": "xywh=6050,3220,925,1250"
+    }
+  }
+}
 ```
 
 

--- a/source/presentation/4.0/index.md
+++ b/source/presentation/4.0/index.md
@@ -191,14 +191,10 @@ comment annotation about part of the previous example's Canvas using FragmentSel
 ```
 
 
-## Presenting Content Resources
 
-This section of the specification uses the use cases listed in the introduction to demonstrate the use of the IIIF Presentation API and introduce additional features.
+## Image Content
 
-
-### Images
-
-#### Use Case 1: Artwork
+### Use Case 1: Artwork
 
 This example is a Manifest with one Canvas, with an image of an artwork "painted" onto the Canvas. It demonstrates the use of the common descriptive properties `label` for the title of the artwork, `metadata` for additional information to display to the user, `summary` for a brief description of the artwork, `rights` to assert a rights statement or license from a controlled vocabulary, `homepage` to link to the artwork's specific web page, `thumbnail` to provide a small image to stand for the Manifest, and `provider` to give information about the publisher of the Manifest.
 
@@ -213,7 +209,7 @@ label, summary, metadata, rights, provider, homepage, thumbnail
 Notice that the painting Annotation is a member of the `items` property of an Annotation Page. While in this case there is only one Annotation Page and one Annotation, the mechanism is needed for consistency when there are multiple Annotation Pages, and it allows for Annotation Pages in general to be separate resources on the web.
 
 
-#### Example 2: Book
+### Example 2: Book
 
 This example is a Manifest with multiple Canvases, each of which represents a page of a book. It demonstrates the use of the `behavior` property to indicate to a client that the object is _paged_: this helps a client generate the correct user experience. The `viewingDirection` property indicates that the book is read left-to-right. In this case, the property is redundant as `left-to-right` is the default value. The Manifest has a `rendering` property linking to a PDF representation; typically a client would offer this as a download or "view as" option. The `start` property is used to tell a client to initialize the view on a particular Canvas, useful if the digitized work contains a large amount of irrelevant front matter or blank pages. The `requiredStatement` is a message that a client MUST show to the user when presenting the Manifest.
 
@@ -224,9 +220,9 @@ requiredStatement, behavior, viewingDirection, (no Ranges), rendering - PDF vers
 
 
 
-### Audio and Video
+## Audio and Video
 
-#### Example: a 45 single with one Timeline per song/side
+### Example: a 45 single with one Timeline per song/side
 
 This example is a Manifest with two Timelines, each of which represent a temporal extent during which a song is played. As in most cases, the Timeline `duration` is the same length as that of Content Resource painted into it. This example is a recording digitized from a 45 RPM 7 inch single. It demonstrates the use of `format` for the audio files' content type, `language` (One song is in English and one is in German), `behavior` with value "autoPlay" that tells a client to automatically advance to the second Timeline after playing the first, `annotations` that link to Annotation Pages of annotations with the motivation `supplementing` that provide the lyrics (one example is given afterwards) - and an `accompanyingContainer` that carries a picture of the single's cover that is shown while the songs are playing.
 
@@ -242,7 +238,7 @@ duration, autoPlay, format, annotations (transcript), language, accompanyingCont
 ...
 ```
 
-#### Example: a movie with subtitles
+### Example: a movie with subtitles
 
 This example is a Manifest with one Canvas that represents the temporal extent of the movie (the Canvas `duration`) and its aspect ratio (given by the `width` and `height` of the Canvas). The example demonstrates the use of a `Choice` annotation body to give two alternative versions of the movie, the `timeMode` property ..., and `placeholderContainer` that provides a poster image to show in place of the video file before the user initiates playback.
 
@@ -264,7 +260,7 @@ duration, behavior=autoplay, format, Choice of video 720p, 4K? (forward ref), ti
 Sometimes, two different formats derived from the same source may have slightly different durations, perhaps a few milliseconds out. What to do...
 
 
-### 3D
+## 3D
 
 3D Content Resources are painted into Scenes.
 
@@ -273,7 +269,7 @@ Scenes have infinite height (y axis), width (x axis) and depth (z axis), where 0
 The positive y axis points upwards, the positive x axis points to the right, and the positive z axis points forwards (a [right-handed cartesian coordinate system](https://en.wikipedia.org/wiki/Right-hand_rule)).
 
 
-#### Example: Static 3D Model of a Spacesuit
+### Example: Static 3D Model of a Spacesuit
 
 
 This example is a Manifest with a single Scene, with a single model of a space suit painted at the Scene's origin.
@@ -302,7 +298,7 @@ backgroundColor: #000
 point selector for positioning
 
 
-#### Example: 3D Model of a Chessboard
+### Example: 3D Model of a Chessboard
 
 Chessboard is a Canvas with image
 more than one model
@@ -318,7 +314,7 @@ interactionMode
 
 
 
-#### Merge the below into the examples or into model
+### Merge the below into the examples or into model
 
 This (no units for scale) allows arbitrarily scaled models to be used, including very small or very large, without needing to deal with very small or very large values. If there is a correspondence to a physical scale, then this can be asserted using the physical dimensions pattern(fwd-ref-to-phys-dims).
 
@@ -517,9 +513,9 @@ Todo add example
 
 
 
-#### Scene-Specific Resources
+### Scene-Specific Resources
 
-##### Camera
+#### Camera
 
 A Camera provides a view of a region of the Scene's space from a particular position within the Scene; the client constructs a viewport into the Scene and uses the view of one or more Cameras to render that region. The size and aspect ratio of the viewport is client and device dependent.
 
@@ -559,7 +555,7 @@ The first Camera defined and not hidden in a Scene is the default Camera used to
 
 
 
-##### Light
+#### Light
 
 This specification defines four types of Light:
 
@@ -718,33 +714,20 @@ When a Scene is nested into another Scene, the `backgroundColor` of the Scene to
 
 
 
-## Annotations and State
+## Annotations
 
 
 
-### Example: Multi-spectral Images with Comments
+### Comment Annotations
 
 
 
-### Annotations
+### Choice of Alternative Resources
 
-non-painting
-
-Comments, tags, etc
-
-transcripts (and back ref to OCR on images etc)
+Example: Multi-spectral Images with Comments
 
 
-#### Comment Annotations
-
-
-
-#### Choice of Alternative Resources
-
-Multispectral here
-
-
-#### Embedded Content
+### Embedded Content
 
 e.g., painting TextualBody on Canvas
 
@@ -755,34 +738,34 @@ It is important to be able to position the textual body of an annotation within 
 
 
 
-#### Non Rectangular Segments
+### Non Rectangular Segments
 
 SvgSelector - move to SpecificResource too ^^
 
 
-#### Style
+### Style
 
 Move to SpecificResource
 
 
-#### Rotation
+### Rotation
 
 
-#### Hotspot Linking and Activation
+### Hotspot Linking and Activation
 
 Move to SpecificResource
 
 
 
 
-#### Annotation Page
+### Annotation Page
 
 "Overlapping elements with a larger z-index cover those with a smaller one."
 link to https://developer.mozilla.org/en-US/docs/Web/CSS/z-index
 
 
 
-#### Annotation Collection
+### Annotation Collection
 
 deal with this:
 https://github.com/IIIF/api/pull/2304/files#diff-cc70f02818f6bed2b14dfbf8bf3206e0825047951c8e83ad56fc73e489f82ac4R1757
@@ -865,10 +848,8 @@ partOf -
 
 
 
-## State
 
-
-### Content State
+## Content State
 
 A Content State is simply any valid IIIF Presentation Resource, or part of a Presentation resource. The following are all Content States that describe a "fragment" of IIIF:
 
@@ -982,14 +963,14 @@ Annotations with the motivation `contentState` are referred to as _content state
 
 Content States are used for the following applications:
 
-#### Load a particular view of a resource or group of resources
+### Load a particular view of a resource or group of resources
 
 In this usage, an annotation with the motivation `contentState` is passed to a client to initialize it with a particular view of a resource. Almost all IIIF Clients initialize from the very simplest form of Content State - a Manifest URI. A more complex Content State might target a particular region of a particular canvas within a Manifest, as in the second example above. A client initialized from such a Content State would load the Manifest, show the particular Canvas, and perhaps zoom in on the target region.
 
 The mechanisms for passing Content State into a client, and exporting a Content State from a client, are given in the Content State Protocol API 2.0 specification, which describes the scenarios in which a URI, or Content State not carried by an annotation, should be interpreted by a Client as a Content State.
 
 
-#### Load a particular view of some resource and modify it
+### Load a particular view of some resource and modify it
 
 In the previous usage, the fragment of IIIF carried by the annotation with the motivation `contentState` provides enough information for a Client to load a resource and show it. This fragment can also carry additional IIIF Presentation API resources not shown in the referred-to resource. For example, in the following example the Content State carries additional annotations not present in the original published Manifest. A client initializing from this Content State would show these additional annotations to the user:
 
@@ -1033,7 +1014,7 @@ TODO: what is the processing algorithm for applying incoming `hidden` ?
 When a Content State annotation carries a Scene, a view might be initialized from a Content State that introduces an additional Camera that shows the user the point of interest. 
 
 
-#### Modify the Container in a particular context
+### Modify the Container in a particular context
 
 The techniques in the previous example are also used within a published IIIF Manifest to modify the contents of a Container in the contexts of different annotations on that Container. This technique allows IIIF to be used for _storytelling_ and other narrative applications beyond simply conveying a static Digital Object into a viewer and leaving subsequent interactions entirely in the control of the user. The `scope` property indicates to the client that the Content State provides valuable context for displaying some aspect of a Scene or other Container. In the case of a commenting annotation, this means that the Content State should be loaded when the commenting annotation is selected or otherwise highlighted. 
 
@@ -1201,19 +1182,19 @@ Use of `scope` is permitted in annotations on any Container type, not just Scene
 
 
 
-#### The `sequence` behavior
+### The `sequence` behavior
 
 // Is this right? Language...
 
 While all AnnotationPage `items` are inherently ordered, an Annotation Page with the behavior `sequence` is explicitly a narrative, and clients should prevent (dissuade) users from jumping about. The presence of `sequence` affects the way a client should interpret the `reset` property described below.
 
-#### Content States on Manifests
+### Content States on Manifests
 
 When an annotation with the motivation `contentState` is provided via the `annotations` property of a Manifest, rather than contextually via `scope`, it is assumed to be generally available for selection by the user at any time. A client may present such as annotations as a menu of views, allowing arbitrary jumping into any Scene (or Canvas or Timeline) from any other point.
 
 // Is there some overlap here with Range?
 
-#### Processing Content States in Scopes: reset
+### Processing Content States in Scopes: reset
 
 When a Content State is applied to a Container such as a Scene, it is assumed to be a "diff" - for example if 3 cameras and 4 lights are already present in the Scene, and a Content State asserts a single new Camera, the default behavior is to add this fourth Camera to the Scene and leave the existing resources as they are.
 
@@ -1291,17 +1272,17 @@ Before applying the content state to the Scene, the client should reset the Scen
 
 // I am assuming reset is always true except in `linear-nav` - otherwise it's completely unpredictable!! or is it... arbitrary navigation, state provided by initialization content states, etc...
 
-#### Contribute additional information permanently
+### Contribute additional information permanently
 
 Rerum inbox scenario - should be covered in CS2 protocol
 
-#### activating - animation and interactions
+### activating - animation and interactions
 
 Annotations with the motivation `activating` are referred to as _activating_ annotations.
 
 There are two uses of `activating` annotations:
 
-##### Triggering a content state
+#### Triggering a content state
 
 An activating annotation links a painting annotation to a content state. When a user interacts with the painting annotation - whether through clicking it, tapping it, or other client-specific behaviors - the linked content state should be processed to modify the Scene or other Container, as in the previous examples. The painting annotation is the target of the activating annotation, and the content state is the body value. Only one content state may be specified in the body array, but the body array may include a `TextualBody` to provide a label for the interaction. The pattern is the same as for the `linking` motivation, but rather than the client opening a new browser window on the resource specified in the `body`, it applies the modification provided by the Content State.
 
@@ -1375,7 +1356,7 @@ The activating annotation is provided in a Container's `annotations` property. I
 
 
 
-##### Triggering a named animation in a model
+#### Triggering a named animation in a model
 
 Sometimes a model file has inbuilt animations. While a description of these is outside the scope of IIIF, because it is 3D-implementation-specific, as long as there is a way to refer to a model's animation(s) by name, we can connect the animation to IIIF resources.
 
@@ -1463,7 +1444,7 @@ if the `target` is an AnimationSelector, then the `body` can ONLY be TextualBody
 
 There is a more general rule here!
 
-#### reset
+### reset
 
 See above...
 


### PR DESCRIPTION
Reorganized current headings to give better visibility of sections (fewer ##### sections)

Added some examples and expanded the text for Containers and Annotations.